### PR TITLE
Update mvm_jungleworks_rc1_adv_manntained_machines.pop

### DIFF
--- a/scripts/population/mvm_jungleworks_rc1_adv_manntained_machines.pop
+++ b/scripts/population/mvm_jungleworks_rc1_adv_manntained_machines.pop
@@ -1164,6 +1164,7 @@ population
 					Name	"Armored Direct Hit Soldier"
 					Class	Soldier
 					Skill	Normal
+					Health	750
 					ClassIcon	soldier_dh_lite_armored
 					Item	"The Direct Hit"
 					Scale	1.45
@@ -1605,7 +1606,7 @@ population
 		{
 			Name	1
 			TotalCurrency	100
-			TotalCount	7
+			TotalCount	6
 			MaxActive	4
 			SpawnCount	1
 			WaitBeforeStarting	0


### PR DESCRIPTION
Corrected the HP of the Armored Direct Hit Soldiers on Wave 3.
Reduced the Giant Pistol Scouts TotalCount from 7 to 6 on Wave 5