### PR TITLE
Small fixes on mvm_bogland_rc10_adv_mud_maker.pop

### DIFF
--- a/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
+++ b/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
@@ -1833,10 +1833,6 @@ population
 				Item	"armored authority"
 				AlwaysGlow	1
 				UseHumanAnimations 1   // Use normal class animations instead of a bot / custom model ones
-				WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
-				{
-					"TF_WEAPON_MINIGUN" 0.4	//let him live lol
-				}
 				ItemAttributes
 				{
 					ItemName	"TF_WEAPON_ROCKETLAUNCHER"
@@ -1949,10 +1945,6 @@ population
 				Attributes	"UseBossHealthBar"
 				Attributes	"MiniBoss"
 				AlwaysGlow	1
-				WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
-				{
-					"TF_WEAPON_MINIGUN" 0.4	//let him live lol
-				}
 				ItemAttributes
 				{
 					ItemName	"The Machina"

--- a/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
+++ b/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
@@ -1606,7 +1606,7 @@ population
 				Template	T_TFBot_Pyro
 				ClassIcon	pyro_reflect_daan
 				Item	"Traffic Cone"
-				Attributes	"AlwaysFireWeapon"
+				//Attributes	"AlwaysFireWeapon"
 				Attributes	"AlwaysCrit"
 			}
 		}
@@ -1833,6 +1833,10 @@ population
 				Item	"armored authority"
 				AlwaysGlow	1
 				UseHumanAnimations 1   // Use normal class animations instead of a bot / custom model ones
+				WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+				{
+					"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+				}
 				ItemAttributes
 				{
 					ItemName	"TF_WEAPON_ROCKETLAUNCHER"
@@ -1894,7 +1898,7 @@ population
 				}
 				Message	
 				{
-					Name	"{red}Field Marshal Mechanus has arrived!"
+					Name	"{blue}Field Marshal Mechanus has arrived!"
 					Delay	0.1
 					Repeats	1
 					Cooldown	3
@@ -1902,7 +1906,7 @@ population
 				}
                 Message	
 				{
-					Name	"{red}Field Marshal Mechanus {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
+					Name	"{blue}Field Marshal Mechanus {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
 					Delay	1.75
 					Repeats	1
 					IfHealthBelow	25000
@@ -1945,6 +1949,10 @@ population
 				Attributes	"UseBossHealthBar"
 				Attributes	"MiniBoss"
 				AlwaysGlow	1
+				WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+				{
+					"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+				}
 				ItemAttributes
 				{
 					ItemName	"The Machina"
@@ -2026,7 +2034,7 @@ population
 				}
 				Message	
 				{
-					Name	"{red}Deadlock has spawned behind you!"
+					Name	"{blue}Deadlock has spawned behind you!"
 					Delay	0.1
 					Repeats	1
 					Cooldown	3
@@ -2034,7 +2042,7 @@ population
 				}
                 Message	
 				{
-					Name	"{red}Deadlock {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
+					Name	"{blue}Deadlock {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
 					Delay	0.875
 					Repeats	1
 					IfHealthBelow	12000
@@ -2185,7 +2193,7 @@ population
 		}
 		WaveSpawn
 		{	
-			Name	"support"
+			Name	"support1"
 			//WaitForAllDead	support
 			TotalCurrency	100
 			TotalCount	16
@@ -2203,7 +2211,7 @@ population
 		}
 		WaveSpawn
 		{
-			Name	"support"
+			Name	"support2"
 			//WaitForAllDead	support
 			TotalCurrency	100
 			TotalCount	18

--- a/scripts/population/mvm_underground_rc3_adv_mining_operation.pop
+++ b/scripts/population/mvm_underground_rc3_adv_mining_operation.pop
@@ -1806,6 +1806,10 @@ population
 						//Attributes AlwaysCrit
 						WeaponRestrictions MeleeOnly
 						//Attributes HoldFireUntilFullReload
+						WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+						{
+							"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+						}
 						Tag	boss_death
 						ItemAttributes
 						{
@@ -1836,6 +1840,10 @@ population
 						Skill	Expert
 						WeaponRestrictions SecondaryOnly
 						Attributes HoldFireUntilFullReload
+						WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+						{
+							"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+						}
 						Tag	boss_death
 						ItemAttributes
 						{
@@ -1866,6 +1874,10 @@ population
 						Skill	Expert
 						WeaponRestrictions PrimaryOnly
 						Attributes HoldFireUntilFullReload
+						WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+						{
+							"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+						}
 						Tag	boss_death
 						//Attributes	"AlwaysCrit"
 						ItemAttributes
@@ -1902,6 +1914,10 @@ population
 						WeaponRestrictions PrimaryOnly
 						Attributes HoldFireUntilFullReload
 						//Attributes AlwaysFireWeapon	//may change this one and the attribute above later again
+						WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+						{
+							"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+						}
 						Tag	boss_death
 						AddCond "TF_COND_SODAPOPPER_HYPE"  
 						RocketCustomParticle eyeboss_projectile  
@@ -1949,6 +1965,10 @@ population
 						WeaponRestrictions PrimaryOnly
 						Attributes HoldFireUntilFullReload
 						Item	"TF_WEAPON_ROCKETLAUNCHER"
+						WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+						{
+							"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+						}
 						Tag	boss_death
 						ItemAttributes
 						{
@@ -1985,6 +2005,10 @@ population
 						Skill	Expert
 						WeaponRestrictions PrimaryOnly
 						Attributes HoldFireUntilFullReload
+						WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+						{
+							"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+						}
 						Tag	boss_death
 						AddCond "TF_COND_PREVENT_DEATH"  
 						ItemAttributes
@@ -2017,6 +2041,10 @@ population
 						Skill	Expert
 						WeaponRestrictions PrimaryOnly
 						Attributes HoldFireUntilFullReload
+						WeaponResist [$SIGSEGV] //Multiplies damage received from weapons listed below
+						{
+							"TF_WEAPON_MINIGUN" 0.4	//let him live lol
+						}
 						Tag	boss_death
 						UseHumanAnimations 1  
 						AddCond "TF_COND_PREVENT_DEATH"  


### PR DESCRIPTION
Wave 6:
Removed the AlwaysFire Attribute on the small Airblast Pyros.

Wave 7:
Changed the Name of both Bosses appearing in the Entrance and Canteen Message from red to blue.

Fixed the Support cutting off at a point in the Wave.

(decided to not go through with the minigun resistance. also sorry for all the commits about my missions if you can see them. im new to github.)