### PR TITLE
Some buffs for obsolescence

### DIFF
--- a/scripts/population/mvm_electricavenue_rc5_exp_obsolescence.pop
+++ b/scripts/population/mvm_electricavenue_rc5_exp_obsolescence.pop
@@ -1,0 +1,5787 @@
+#base robot_giant.pop
+#base robot_standard.pop
+// #base robot_gatebot.pop
+// #base conga_weapons_v2.pop
+//Mission by Conga Dispenser and Sergeant Table
+population
+{
+	StartingCurrency	800
+	BodyPartScaleSpeed 99
+	RespawnWaveTime	4
+	CanBotsAttackWhileInSpawnRoom	no
+	AddSentryBusterWhenDamageDealtExceeds	3000
+	AddSentryBusterWhenKillCountExceeds	10
+	TextPrintTime 0
+	PrecacheModel "models\bots\soldier_boss\bot_soldier_boss_gibby.mdl"
+	PrecacheModel "models/buildables/amplifier_test/amplifier.mdl"
+	PrecacheSound "vs_architect.mp3"
+	PrecacheSound "woter.mp3"
+	PrecacheSound "major_shocks.wav"
+	PrecacheSound "finalphase.mp3"
+	PrecacheSound "burnedatthestake.mp3"
+	PrecacheSound "planned_obsolescence_death.mp3"
+	PrecacheParticle "steam_train"
+	PrecacheParticle "env_rain_512x1792"
+	PrecacheParticle "env_rain_001"
+	PrecacheParticle "env_rain_512"
+	CustomWeapon
+	{
+		"no_you_cannot_have_this_weapon"
+        {
+            OriginalItemName "tf_weapon_rocketlauncher"
+            "projectile spread angle penalty" 35
+            "projectile gravity" 750
+			"projectile speed decreased" 0.55
+			"ignores other projectiles" 1
+            "damage bonus" 1.5
+            "blast dmg to self increased" 0
+            "self dmg push force decreased" 0
+            "mult dmg vs giants" 2.5 // You know if you manage to reflect
+            "projectile trail particle" "manmelter_projectile_trail"
+            "explosion particle" "rd_robot_explosion_smoke_linger"
+            "no self effect" 1
+        }
+	}
+	Mission
+	{
+		Objective	DestroySentries
+		Where	spawnbot
+		BeginAtWave	1
+		RunForThisManyWaves	6
+		InitialCooldown	30
+		CooldownTime	45
+		DesiredCount	1
+		TFBot
+		{
+			Template	T_TFBot_SentryBuster
+		}
+	}
+	Mission
+	{
+		Objective	Spy
+		Where	spawnbot
+		BeginAtWave	1
+		RunForThisManyWaves	1
+		InitialCooldown	30
+		CooldownTime	45
+		DesiredCount	2
+		TFBot
+		{
+			Template	T_TFBot_Spy
+		}
+	}
+	Mission
+	{
+		Objective	Spy
+		Where	spawnbot
+		BeginAtWave	4
+		RunForThisManyWaves	2
+		InitialCooldown	30
+		CooldownTime	45
+		DesiredCount	2
+		TFBot
+		{
+			Template	T_TFBot_Spy
+		}
+	}
+//	Mission
+//	{
+//		Objective	Sniper
+//		Where	spawnbot
+//		BeginAtWave	4
+//		RunForThisManyWaves	1
+//		InitialCooldown	30
+//		CooldownTime	25
+//		DesiredCount	2
+//		TFBot
+//		{
+//			Template	T_TFBot_Sniper
+//		}
+//	}
+	Mission
+	{
+		Objective	Engineer
+		Where	spawnbot
+		BeginAtWave 4
+		RunForThisManyWaves 1
+		InitialCooldown	30
+		CooldownTime	30
+		DesiredCount	1
+		TFBot
+		{
+			Template	T_TFBot_Engineer_Sentry_Teleporter
+		}
+	}
+	Mission
+	{
+		Objective	Spy
+		Where	spawnbot
+		BeginAtWave	6
+		RunForThisManyWaves	1
+		InitialCooldown	60
+		CooldownTime	45
+		DesiredCount	2
+		TFBot
+		{
+			Template	T_TFBot_Spy
+		}
+	}
+	
+	PointTemplates
+	{
+		MissionName
+		{
+			point_populator_interface
+			{
+				"targetname" "pop_interface"
+			}
+			filter_tf_bot_has_tag
+			{
+				"targetname" "bosstag"
+				"Negated" "1"
+                "require_all_tags" "1"
+				"tags" "boss_bot"
+			}
+			filter_tf_bot_has_tag
+			{
+				"targetname" "backuptag"
+				"tags" "bossbackup"
+			}
+			filter_activator_class
+            {
+                "targetname" "filter_is_not_player"
+                "Negated" "1"
+                "filterclass" "player"
+            }
+            filter_activator_class
+            {
+                "targetname" "filter_is_player"
+                "Negated" "0"
+                "filterclass" "player"
+            }
+            filter_activator_tfteam 
+            {
+                "targetname" "filter_is_blue"
+                "Negated"	"0"
+                "TeamNum"	"3"
+            }	
+            filter_activator_tfteam 
+            {
+                "targetname" "filter_is_red"
+                "Negated"	"0"
+                "TeamNum"	"2"
+            }
+			filter_multi
+			{
+				"targetname" "is_boss"
+				"Negated" "1"
+				"FilterType" "0"
+				"Filter01" "bosstag"
+			}
+            filter_multi 
+            {
+                "targetname" "filter_is_red_player"
+                "Negated"	"0"
+                "FilterType" "0" //and				
+                "Filter01"   "filter_is_red"
+                "Filter02"   "filter_is_player"
+            }
+            filter_tf_condition
+            {
+                "targetname" "_filter_is_not_ubered"
+                "Negated"	"1"
+                "condition"  "5" //medigun uber
+            }
+            filter_tf_condition
+            {
+                "targetname" "_filter_is_not_ubered2"
+                "Negated"	"1"
+                "condition"  "52" //canteen uber
+            }
+            filter_tf_condition
+            {
+                "targetname" "_filter_is_not_ubered3"
+                "Negated"	"1"
+                "condition"  "51" //hidden uber
+            }
+            filter_tf_condition
+            {
+                "targetname" "_filter_is_not_ubered4"
+                "Negated"	"1"
+                "condition"  "57" //WoF uber
+            }
+            filter_multi 
+            { // is red player, AND is NOT ubered
+                "targetname" "filter_is_red_not_ubered"
+                "Negated"	"0"
+                "FilterType" "0" //and				
+                "Filter01"   "filter_is_red"
+                "Filter02"   "_filter_is_not_ubered"
+                "Filter03"   "_filter_is_not_ubered2"
+                "Filter04"   "_filter_is_not_ubered3"
+                "Filter05"   "_filter_is_not_ubered4"
+                "Filter06"   "filter_is_player"
+            }
+            filter_multi 
+            {
+                "targetname" "filter_not_ubered"
+                "Negated"	"0"
+                "FilterType" "0"
+                "Filter01"   "_filter_is_not_ubered"
+                "Filter02"   "_filter_is_not_ubered2"
+                "Filter03"   "_filter_is_not_ubered3"
+                "Filter04"   "_filter_is_not_ubered4"
+                "Filter05"   "filter_is_player"
+            }
+		}
+		scatter_rockets_base
+        {
+            RemoveIfKilled "location"
+            KeepAlive 1
+			OnParentKilledOutput
+			{
+				Target mimicname
+				Action "firemultiple"
+				Param 10
+				Delay 0.1
+			}
+			OnParentKilledOutput
+			{
+				Target location
+				Action Kill
+				Delay 0.2
+			}
+			OnParentKilledOutput
+			{
+				Target "mimicname"
+				Action "$setkey$angles"
+				Param "270 0 0"
+				Delay 0
+			}
+			OnSpawnOutput
+			{
+				Target "mimicname"
+				Action "$SetOwner"
+				Param  "!activator"
+				Delay  0
+			}
+			tf_point_weapon_mimic
+			{
+				"targetname" "mimicname"
+				"origin"     "0 0 25"
+				"angles"     "0 0 0"
+				"teamnum"    "3"
+				"$weaponname" "no_you_cannot_have_this_weapon"
+			}
+			
+        }
+		bossdeathanimation
+		{
+			OnSpawnOutput
+			{
+				Target "tf_gamerules"
+				Action "PLayVO"
+				Param "burnedatthestake.mp3"
+				Delay 3
+			}
+			OnSpawnOutput
+			{
+				Target "deezexplosions"
+				Action "pickrandomshuffle"
+				Delay 0
+			}
+			OnSpawnOutput
+			{
+				Target "bosstime2"
+				Action "FadeOut"
+				Param 5
+				Delay 0
+			}
+			OnSpawnOutput
+			{
+				Target "deezexplosions"
+				Action "pickrandomshuffle"
+				Delay 1
+			}
+			OnSpawnOutput
+			{
+				Target "deezexplosions"
+				Action "pickrandomshuffle"
+				Delay 2
+			}
+			OnSpawnOutput
+			{
+				Target "deezexplosions"
+				Action "pickrandomshuffle"
+				Delay 2.3
+			}
+			OnSpawnOutput
+			{
+				Target "blowthemf"
+				Action "enable"
+				Delay 3
+			}
+			OnSpawnOutput
+			{
+				Target "finalboss_defeat"
+				Action "enable"
+				Delay 0
+			}
+			OnSpawnOutput
+			{
+				Target "finalboss_defeat"
+				Action "SetPlaybackRate"
+				Param 0.0001
+				Delay 0.1
+			}
+			OnSpawnOutput
+			{
+				Target "finalboss_defeat"
+				Action "SetPlaybackRate"
+				Param 0.35
+				Delay 3
+			}
+			OnSpawnOutput
+			{
+				Target "finalboss_defeat"
+				Action "SetPlaybackRate"
+				Param 5
+				Delay 8.5
+			}
+			OnSpawnOutput
+			{
+				Target "boss_is_dead"
+				Action "Start"
+				Delay 3
+			}
+			OnSpawnOutput
+			{
+				Target "finalboss_defeat"
+				Action "SetAnimation"
+				Param "dieviolent"
+				Delay 2.9
+			}
+			// OnParentKilledOutput
+			// {
+			// 	Target "boss_about_to_blow"
+			// 	Action "start"
+			// 	Delay 3
+			// }
+			// OnParentKilledOutput
+			// {
+			// 	Target "finalboss_defeat"
+			// 	Action "SetPlaybackRate"
+			// 	Param "1.5"
+			// 	Delay 6
+			// }
+			logic_timer
+			{
+				"targetname" "blowthemf"
+				"OnTimer" "deezexplosions,pickrandomshuffle,,0,-1"
+				"RefireTime" "0.27"
+				"StartDisabled" "1"
+			}
+			logic_case
+			{
+				"targetname" "deezexplosions"
+				"OnCase01"	"generator_explosion,trigger,,0,-1"
+				"OnCase02"	"generator_explosion1,trigger,,0,-1"
+				"OnCase03"	"generator_explosion2,trigger,,0,-1"
+				"OnCase04"	"generator_explosion3,trigger,,0,-1"
+				"OnCase05"	"generator_explosion4,trigger,,0,-1"
+				"OnCase06"	"generator_explosion5,trigger,,0,-1"
+				"OnCase07"	"generator_explosion6,trigger,,0,-1"
+				"OnCase08"	"generator_explosion7,trigger,,0,-1"
+			}
+			
+
+			logic_relay
+			{
+				"targetname"	"generator_explosion"
+				"OnTrigger"		"explosion,start,,0,-1"
+				"OnTrigger"		"explosion,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|weapons\airstrike_small_explosion_01.wav,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"generator_explosion1"
+				"OnTrigger"		"explosion1,start,,0,-1"
+				"OnTrigger"		"explosion1,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|weapons\airstrike_small_explosion_02.wav,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"generator_explosion2"
+				"OnTrigger"		"explosion2,start,,0,-1"
+				"OnTrigger"		"explosion2,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|ambient\explosions\explode_7.wav,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"generator_explosion3"
+				"OnTrigger"		"explosion3,start,,0,-1"
+				"OnTrigger"		"explosion3,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|weapons\airstrike_small_explosion_03.wav,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"generator_explosion4"
+				"OnTrigger"		"explosion4,start,,0,-1"
+				"OnTrigger"		"explosion4,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|ambient\explosions\explode_3.wav,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"generator_explosion5"
+				"OnTrigger"		"explosion5,start,,0,-1"
+				"OnTrigger"		"explosion5,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|weapons\airstrike_small_explosion_02.wav,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"generator_explosion6"
+				"OnTrigger"		"explosion6,start,,0,-1"
+				"OnTrigger"		"explosion6,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|ambient\explosions\explode_7.wav,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"generator_explosion7"
+				"OnTrigger"		"explosion7,start,,0,-1"
+				"OnTrigger"		"explosion7,stop,,0.1,-1"
+				"OnTrigger"		"player,$PlaySoundToSelf,=50|ambient\explosions\explode_4.wav,0,-1"
+			}
+			info_particle_system
+			{
+				"targetname" "explosion"
+				"origin" "20 20 30"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			info_particle_system
+			{
+				"targetname" "explosion1"
+				"origin" "0 0 110"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			info_particle_system
+			{
+				"targetname" "explosion2"
+				"origin" "-30 0 70"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			info_particle_system
+			{
+				"targetname" "explosion3"
+				"origin" "0 -20 60"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			info_particle_system
+			{
+				"targetname" "boomexplosion"
+				"origin" "20 -20 90"
+				"angles" "0 0 0"
+				"effect_name" "hightower_explosion"
+				
+			}
+			
+			info_particle_system
+			{
+				"targetname" "explosion4"
+				"origin" "0 20 60"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			info_particle_system
+			{
+				"targetname" "explosion5"
+				"origin" "20 0 50"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			
+
+			info_particle_system
+			{
+				"targetname" "explosion6"
+				"origin" "0 0 30"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			info_particle_system
+			{
+				"targetname" "explosion7"
+				"origin" "0 10 50"
+				"angles" "0 0 0"
+				"effect_name" "rd_robot_explosion"
+				
+			}
+			info_particle_system
+			{
+				"targetname" "boss_is_dead"
+				"origin" "0 0 120"
+				"angles" "-90 0 0"
+				"effect_name" "charge_up"
+			}
+			KeepAlive 1
+			info_particle_system
+			{
+				"targetname" "boss_is_dead1"
+				"origin" "0 0 70"
+				"angles" "-90 0 0"
+				"effect_name" "mvm_tank_destroy"
+			}
+			info_particle_system
+			{
+				"targetname" "boss_is_dead1"
+				"origin" "0 0 120"
+				"angles" "-90 0 0"
+				"effect_name" "hammer_bell_ring_shockwave"
+			}
+			prop_dynamic
+			{
+				"targetname" "finalboss_defeat"
+				"origin" "0 0 0"
+				"angles" "0 0 0"
+				"color" "255 255 255"
+				"model" "models\bots\soldier_boss\bot_soldier_boss_gibby.mdl"
+				"modelscale" "1.8"
+				"defaultanim" "primary_death_burning"
+				"disablebonefollowers" "1"
+				"OnAnimationDone" "!self,SetPlaybackRate,0,-1,-1"
+				"OnAnimationDone" "bossdeath1,trigger,-1,-1"
+				"OnAnimationDone" "!self,Kill,,-1,-1"
+				"OnAnimationDone" "blowthemf,disable,,-1,-1"
+				"OnAnimationDone" "boss_is_dead1,start,,-1,-1"
+				"OnAnimationDone" "tf_gamerules,PlayVO,planned_obsolescence_death.mp3,-1,-1"
+				"startdisabled" "1"
+				"skin" "1"
+			}
+		}
+		bossattachments
+		{
+			KeepAlive 1
+			OnParentKilledOutput
+			{
+				Target "bossdeathanimation"
+				Action "ForceSpawnAtEntityOrigin"
+				Param "boss_thingy"
+			}
+			OnSpawnOutput
+            {
+                Target boss_thingy
+				Action SetParent
+				Param "!activator"
+				Delay 0.05
+            }
+			OnSpawnOutput
+            {
+                Target temporary_solution
+                Action $SetOwner
+                Param "@p@boss_thingy"
+                Delay 2
+            }
+			KeepAlive 1
+            info_target
+            {
+                "TargetName" "boss_thingy"
+                "origin" "0 0 0"
+            }
+			logic_relay
+			{
+				"targetname" "bossattack_trigger"
+				"OnTrigger"  "bossattacksforfinale,pickrandomshuffle,,0,-1"
+				"startdisabled" "1"
+				"spawnflags" "2"
+			}
+			logic_relay
+			{
+				"targetname" "attackchooser"
+				"OnTrigger"  "choosephase1,trigger,,0,-1"
+				"OnTrigger"  "choosephase2,trigger,,0,-1"
+			}
+			logic_relay
+			{
+				"targetname" "choosephase1"
+				"OnTrigger"  "phase1,PickRandomShuffle,,0,-1"
+				"spawnflags" "2"
+				"startdisabled" "1"
+			}
+			logic_relay
+			{
+				"targetname" "choosephase2"
+				"OnTrigger"  "phase2,PickRandomShuffle,,0,-1"
+				"spawnflags" "2"
+				"startdisabled" "1"
+			}
+			logic_case
+			{
+				"targetname" "phase1"
+				"OnCase01" "pop_interface,ChangeBotAttributes,specialattackjump,0.0,-1"
+				"OnCase02" "pop_interface,ChangeBotAttributes,normalcritrapid,0.0,-1"	
+				"OnCase03" "pop_interface,ChangeBotAttributes,loosecannonscatter,0.0,-1"
+				"OnCase04" "pop_interface,ChangeBotAttributes,sucknblow,0.0,-1"	
+				"OnCase05" "pop_interface,ChangeBotAttributes,loosecannonscatter,0.0,-1"
+			}
+			logic_case
+			{
+				"targetname" "phase2"
+				"OnCase01" "pop_interface,ChangeBotAttributes,prehastycommons,0.0,-1"
+				"OnCase02" "pop_interface,ChangeBotAttributes,healingshotgunrapid,0.0,-1"	
+				"OnCase03" "pop_interface,ChangeBotAttributes,nuker,0.0,-1"
+				"OnCase04" "pop_interface,ChangeBotAttributes,loosecannonscatter,0.0,-1"	
+				"OnCase05" "pop_interface,ChangeBotAttributes,nuker,0.0,-1"
+				"OnCase06" "pop_interface,ChangeBotAttributes,sucknblow,0.0,-1"	
+			}
+			logic_case
+			{
+				"targetname" "bossattacksforfinale"
+				"OnCase01" "pop_interface,ChangeBotAttributes,nukermultiple,0,-1"
+				"OnCase02" "pop_interface,ChangeBotAttributes,healingshotgunrapid,0,-1"	
+				"OnCase03" "pop_interface,ChangeBotAttributes,specialattackjump2,0,-1"
+				"OnCase04" "pop_interface,ChangeBotAttributes,spiralrocketattackofdoom,0,-1"
+				"OnCase05" "pop_interface,ChangeBotAttributes,totheskiesandairstrike,0,-1"
+				"OnCase06" "pop_interface,ChangeBotAttributes,jumpingintothewater,0,-1"
+			}
+			logic_relay
+            {
+                "targetname" "jumpattack"
+                "OnTrigger"  "!activator,$PlaySequence,taunt_zoomin_broom_exit,0,-1"
+                "OnTrigger"  "!activator,$PlaySequence,run_PRIMARY,1,-1"
+                "OnTrigger"  "jumpattackdust*,start,,0.8,-1"
+                "OnTrigger"  "jumpattackdust*,stop,,1,-1"
+                "OnTrigger"  "jumpattacksfx*,playsound,,0.8,-1"
+                "OnTrigger"  "jumpattacksfx*,stopsound,,1,-1"
+                "OnTrigger"  "shake_boss,startshake,,0.8,-1"
+                "OnTrigger"  "byeeeee,enable,,0.8,-1"
+				"OnTrigger"  "byeeeee,disable,,0.81,-1"
+				"OnTrigger" "!activatorRunScriptCodelocal hWeapon = self.GetActiveWeapon(); if(hWeapon) hWeapon.EnableDraw()1.1-1"
+            }
+			logic_relay
+			{
+				"targetname" "watersplashes"
+				"OnTrigger"  "water,start,,0,-1"
+				"OnTrigger"  "agua,start,,0.1,-1"
+				"OnTrigger"  "water3,start,,0.1,-1"
+				"OnTrigger"  "water4,start,,0.2,-1"
+				"OnTrigger"  "water5,start,,0.3,-1"
+				"OnTrigger"  "water6,start,,0.4,-1"
+				"OnTrigger"  "water7,start,,0.5,-1"
+				"OnTrigger"  "water8,start,,0.6,-1"
+				"OnTrigger"  "water*,stop,,2,-1"
+				"OnTrigger"  "agua,stop,,3,-1"
+				"ontrigger"  "isogyou,start,,0.5,-1"
+				"ontrigger"  "isogyou,stop,,12.5,-1"
+				// "OnTrigger"  "tf_gamerules,playvo,woter.mp3,0,-1"
+				"OnTrigger"  "playerrunscriptcodeScreenShake(self.GetOrigin(), 5, 8, 1, 50000, 0, true)0-1"
+				"OnTrigger"  "playerrunscriptcodeScreenFade(null, 64, 119, 158, 50, 0.6, 0.1, 1)0.1-1"
+				"OnTrigger"  "player,SetScriptOverlayMaterial,effects/water_warp,0.4,-1"
+				"OnTrigger"  "player,SetScriptOverlayMaterial,,15.5,-1"
+				"OnTrigger"  "player,$AddCond,27,0.1,-1"
+				"OnTrigger"  "player,$RemoveCond,27,15.5,-1"
+			}
+			info_particle_system
+			{
+				"targetname"   "water"
+				"origin"       "0 0 200"
+				"angles"		"-180 0 0"
+				"effect_name"  "waterfall_bottommist"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water"
+				"origin"       "0 200 200"
+				"angles"		"-180 0 0"
+				"effect_name"  "waterfall_bottommist"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water"
+				"origin"       "0 -200 200"
+				"angles"		"-180 0 0"
+				"effect_name"  "waterfall_bottommist"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "agua"
+				"origin"       "0 0 300"
+				"angles"	   "0 0 0"
+				"effect_name"  "waterfall_bottommist"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "agua"
+				"origin"       "0 150 300"
+				"angles"	   "0 0 0"
+				"effect_name"  "waterfall_bottommist"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "agua"
+				"origin"       "0 -150 300"
+				"angles"	   "0 0 0"
+				"effect_name"  "waterfall_bottommist"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water3"
+				"origin"       "0 0 100"
+				"angles"	   "-180 0 0"
+				"effect_name"  "env_rain_512"
+				"start_active" "0"
+			}
+			
+			info_particle_system
+			{
+				"targetname"   "water4"
+				"origin"       "0 0 170"
+				"angles"	   "-180 0 0"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water4"
+				"origin"       "0 0 170"
+				"angles"	   "-180 -40 0"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water4"
+				"origin"       "0 0 170"
+				"angles"	   "-180 40 0"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water5"
+				"origin"       "0 0 240"
+				"angles"	   "-180 0 0"
+				"effect_name"  "env_rain_512"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water6"
+				"origin"       "0 0 310"
+				"angles"	   "-180 0 0"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water7"
+				"origin"       "0 0 380"
+				"angles"	   "-180 0 0"
+				"effect_name"  "env_rain_512"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water8"
+				"origin"       "0 0 450"
+				"angles"	   "-180 0 0"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "water8"
+				"origin"       "0 0 900"
+				"angles"	   "0 0 0"
+				"effect_name"  "env_rain_512"
+				"start_active" "0"
+			}
+			 info_particle_system
+            {
+                "targetname"   "jumpattackdust"
+                "origin"       "0 0 0"
+                "effect_name"  "hammer_impact_button"
+                "start_active" "0"
+            }
+            info_particle_system
+            {
+                "targetname"   "jumpattackdust"
+                "origin"       "0 0 0"
+                "effect_name"  "hammer_impact_button_dust2"
+                "start_active" "0"
+            }
+            ambient_generic
+            {
+                "targetname" "jumpattacksfx"
+                "message"    "ambient\explosions\explode_4.wav"
+                "health"     "10"
+                "pitch"      "100"
+                "radius"     "6000"
+                "spawnflags" "32"
+                "origin"     "0 0 100"
+            }
+             ambient_generic
+            {
+                "targetname" "jumpattacksfx"
+                "message"    "ambient\explosions\explode_4.wav"
+                "health"     "10"
+                "pitch"      "100"
+                "radius"     "6000"
+                "spawnflags" "32"
+                "origin"     "0 0 100"
+            }
+			trigger_apply_impulse 
+            {
+                "targetname" "byeeeee"
+                "origin" "0 0 0"
+                "maxs" "1200 1200 400"
+                "mins" "-1200 -1200 -0"
+                "spawnflags" "1"
+                "filtername" "filter_is_red_player"
+                "force" "1000"
+                "impulse_dir" "262 10 0"
+				"StartDisabled" "1"
+				"OnStartTouch" "!activatorRunScriptCodeself.ApplyAbsVelocityImpulse(Vector(0,0,1300))0-1"
+				"OnStartTouch" "!activatorRunScriptCodeself.AddCustomAttribute(`increased air control`,4,-1)0-1"
+				"OnStartTouch" "!activatorRunScriptCodeself.RemoveCustomAttribute(`increased air control`)7-1"
+				"OnStartTouch" "!activator,$AddCond,80,1,-1"
+				"OnStartTouch" "!activator,$AddCond,125,1,-1"
+				"OnStartTouch" "!activator,$RemoveCond,125,7,-1"
+            }
+			point_push
+			{
+				"targetname" "suck"
+				"spawnflags" "9"
+				"origin" "0 0 0"
+				"StartDisabled" "1"
+				"radius" "1224"
+				"magnitude" "-100"
+				"filtername" "filter_is_red_player"
+			}
+			point_push
+			{
+				"targetname" "suck"
+				"spawnflags" "9"
+				"origin" "0 0 0"
+				"StartDisabled" "1"
+				"radius" "256"
+				"magnitude" "-196"
+				"filtername" "filter_is_red_player"
+			}
+			trigger_remove_tf_player_condition
+			{
+				"targetname" "readyingthebackup"
+				"filtername" "backuptag"
+				"condition" "87"
+				"mins" "-256 -256 -256"
+				"maxs" "256 256 256"
+				"spawnflags" "1"
+			}
+			trigger_hurt
+			{
+				"targetname" "jumpcatapult"
+				"filtername" "filter_is_red_not_ubered"
+				"StartDisabled" "1"
+				"mins" "-320 -320 -320"
+				"maxs" "320 320 320"
+				"damage" "250"
+				"damagetype" "64"
+				"spawnflags" "1"
+			}
+			point_push
+			{
+				"targetname" "blow"
+				"spawnflags" "9"
+				"origin" "0 0 256"
+				"StartDisabled" "1"
+				"radius" "256"
+				"magnitude" "512"
+				"filtername" "filter_is_red_player"
+			}
+			trigger_catapult
+			{
+				"targetname" "jumpcatapult"
+				"filtername" "filter_is_red_player"
+				"StartDisabled" "1"
+				"mins" "-128 -128 -64"
+				"maxs" "128 128 64"
+				"playerSpeed" "512"
+				"launchDirection" "-90 0 0"
+				"spawnflags" "1"
+			}
+			info_target
+			{
+				"targetname" "teleporttarget"
+				"origin" "0 0 128"
+			}
+			trigger_stun
+            {
+                "move_speed_reduction" "0"
+                "origin" "0 0 0"
+                "spawnflags" "1"
+                "StartDisabled" "1"
+                "filtername" "filter_is_blue"
+                "stun_duration" "5"
+                "stun_effects" "0"
+                
+                "stun_type" "1"
+                "targetname" "callateputa"
+                "trigger_delay" "0"
+
+                "mins" "-117 -99 -140"
+                "maxs" "117 99 140"
+            }
+		}
+		itscalledflairsir
+		{
+			prop_dynamic
+			{
+				"targetname" "meganoob"
+				"model"      "models/workshop/player/items/soldier/taunt_rocket_jockey/taunt_rocket_jockey.mdl"
+				"angles"	 "0 90 0"
+				"origin"     "0 0 -24"
+				"disableshadows" "1"
+			}
+		}
+		ubergeneratortutorial_template
+		{
+			RemoveIfKilled "uber_generating_for_boss"
+			OnSpawnOutput
+			{
+				Target "tf_gamerules"
+				Action "PLayVO"
+				Param "ambient\machines\thumper_startup1.wav"
+			}
+			OnSpawnOutput
+			{
+				Target "heylook"
+				Action "Show"
+				Delay 0
+			}
+			OnSpawnOutput
+			{
+				Target "uber_generating_for_boss"
+				Action "Sethealth"
+				Param 2000 // Fuck you 6k hp // 864, It's too tanky :
+			}
+			OnSpawnOutput
+			{
+				Target "uber_generating_for_boss"
+				Action "$setmodeloverride"
+				Param "models/buildables/amplifier_test/amplifier.mdl"
+			}
+			obj_dispenser
+			{
+				"targetname" "uber_generating_for_boss"
+				"origin" "969 -198 -383"
+				"teamnum" "3"
+				"SolidToPlayer" "0"
+				"defaultupgrade" "1"
+				"$attributeoverride" 1
+				//"$radiusmult" 3
+				"OnDestroyed" "bignet,RunScriptCode,TextualTimer.Set(120),0,1"
+				"OnDestroyed" "tf_gamerules,PlayVO,vo\announcer_time_added.mp3,0,-1"
+				// "OnDestroyed" "@p@boss_thingy,$TakeDamage,5000,0.1,1"
+				"OnDestroyed" "@p@boss_thingy,$RemoveCond,73,0.1,1"
+				"OnDestroyed" "@p@boss_thingy,$RemoveCond,51,0,1"
+				"OnDestroyed" "@p@boss_thingy,$RemoveCond,7,0.1,1"
+				"OnDestroyed" "callateputa,enable,,0.1,1"
+				"OnDestroyed" "callateputa,disable,,0.2,1"
+				"OnDestroyed" "tf_gamerules,PlayVO,ambient\machines\thumper_shutdown1.wav,0.1,1"
+				"OnDestroyed" "@p@boss_thingyRunScriptCodeself.AddCustomAttribute(`gesture speed increase`,1,-1)0-1"
+				"OnDestroyed" "choosephase1,enable,,6,1"
+				"OnDestroyed" "tf_gamerules,PlayVO,player\invulnerable_off.wav,0,-1"
+				"OnDestroyed" "phase1,PickRandomShuffle,,7,-1"
+
+			}
+			training_annotation
+            {
+                "targetname"   "heylook"
+                "display_text" "Destroy the Uber Generators to Prevent It From Healing"
+                "lifetime"     "8"
+                "origin"       "969 -198 -365"
+            }
+			info_particle_system
+            {
+                "targetname"   "beam"
+                "origin"       "969 -198 -383"
+                "effect_name"  "teleporter_mvm_bot_persist"
+                "start_active" "1"
+            }
+		}
+		ubergeneratortutorial_template_2
+		{
+			RemoveIfKilled "uber_generating_for_boss"
+			OnSpawnOutput
+			{
+				target boss_hint
+				action Show
+			}
+			training_annotation
+			{
+				"targetname"   "boss_hint"
+				"display_text" "Uber Generator!"
+				"lifetime"     "8"
+				"origin" "0 0 0"
+			}
+			OnSpawnOutput
+			{
+				Target "tf_gamerules"
+				Action "PLayVO"
+				Param "mvm\mvm_tele_deliver.wav"
+			}
+			OnParentKilledOutput
+			{
+				Target flag_glow
+				Action Enable
+				Delay 1
+			}
+			OnSpawnOutput
+			{
+				Target "uber_generating_for_boss"
+				Action "Sethealth"
+				Param 2000 // Fuck you 6k hp // 864, It's too tanky :
+			}
+			OnSpawnOutput
+			{
+				Target "uber_generating_for_boss"
+				Action "$setmodeloverride"
+				Param "models/buildables/amplifier_test/amplifier.mdl"
+			}
+			tf_glow
+            {
+                "GlowColor" "0 176 199 255"
+                "target" "uber_generating_for_boss"
+				"targetname" "flag_glow"
+				"startdisabled" "1"
+            }
+			obj_dispenser
+			{
+				"targetname" "uber_generating_for_boss"
+				"origin" "0 0 0"
+				"teamnum" "3"
+				"SolidToPlayer" "0"
+				"defaultupgrade" "1"
+				"$attributeoverride" 1
+				//"$radiusmult" 3
+				"OnDestroyed" "ubergen2,Add,1,0,1"
+				"OnDestroyed" "tf_gamerules,PlayVO,ambient\machines\thumper_shutdown1.wav,0.1,1"
+			}
+			info_particle_system
+            {
+                "targetname"   "beam"
+                "origin"       "0 0 0"
+                "effect_name"  "teleporter_mvm_bot_persist"
+                "start_active" "1"
+            }
+		}
+		bosswavelogic
+		{
+			OnSpawnOutput
+			{
+				Target bignet
+				Action RunScriptCode
+				Param "
+				IncludeScript(`textualtimer_v3`, getroottable())
+				TextualTimer.SetParams({
+					minutes = 1
+					seconds = 0
+					x = -1
+					y = 0.77
+					color = `0 255 555`
+					relayname = `redlose_relay`
+					text_prepend = `FACTORY RESET: `
+					automatic = false 
+        		})
+				"
+			}
+			OnSpawnOutput
+			{
+				Target "trigger_hurt*"
+				Action "AddOutput"
+				Param "targetname todisable"
+				Delay 0.5
+			}
+			OnSpawnOutput
+			{
+				Target "hhhhhhh"
+				Action "Trigger"
+				Delay 1
+			}
+			logic_relay
+			{
+				"targetname" "hhhhhhh"
+				"OnTrigger"  "pop_interface,$PauseWavespawn,disableformidboss,0,-1"
+				"OnTrigger"  "pop_interface,$PauseWavespawn,forthesplashattack,0,-1"
+				"OnTrigger"  "pop_interface,$PauseWavespawn,disablefor_ubergenerator,0,-1"
+				"OnTrigger"  "player,SetScriptOverlayMaterial,,0,-1"
+			}
+			OnSpawnOutput
+			{
+				Target "hatch_hurt*"
+				Action "kill"
+				Delay 0
+			}
+			info_target
+			{
+				"targetname" "mightspawn"
+				"origin"     "3828 -856 0"
+			}
+			info_target
+			{
+				"targetname" "mightspawn2"
+				"origin"     "4878 -631 0"
+			}
+			info_target
+			{
+				"targetname" "mightspawn3"
+				"origin"     "4601 -1622 128"
+			}
+			info_target
+			{
+				"targetname" "mightspawn4"
+				"origin"     "2082 -780 -127"
+			}
+			info_target
+			{
+				"targetname" "mightspawn5"
+				"origin"     "2803 -2291 128"
+			}
+			info_target
+			{
+				"targetname" "mightspawn6"
+				"origin"     "3622 -3176 0"
+			}
+			logic_case
+			{
+				"targetname" "randomizedspawnsforgenerators"
+				"OnCase01" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn,0.0,-1"
+				"OnCase02" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn2,0.0,-1"	
+				"OnCase03" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn3,0.0,-1"
+				"OnCase04" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn4,0.0,-1"
+				"OnCase05" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn5,0.0,-1"
+				"OnCase06" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn6,0.0,-1"
+			}
+			logic_case
+			{
+				"targetname" "randomizedspawnsforgenerators_final"
+				"OnCase01" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn,0.0,-1"
+				"OnCase02" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn2,0.0,-1"	
+				"OnCase03" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn3,0.0,-1"
+				"OnCase04" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn4,0.0,-1"
+				"OnCase05" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn5,0.0,-1"
+				"OnCase06" "ubergeneratortutorial_template_2,ForceSpawnAtEntityOrigin,mightspawn6,0.0,-1"
+			}
+			math_counter
+            {
+                "targetname" "ubergen2"
+                "startvalue" "0" //Probably defaults to 0, but still.
+                "min" "0"
+                "max" "3" //Whatever value you desire
+				"OnHitMax" "ubergen2,SetValue,0,2,-1"
+				"OnHitMax" "ubergen2,SetHitMax,5,2,-1"
+                "OnHitMax" "bignet,RunScriptCode,TextualTimer.Set(150),0,1"
+				"OnHitMax" "tf_gamerules,PlayVO,player\invulnerable_off.wav,0,-1"
+				"OnHitMax" "tf_gamerules,PlayVO,vo\announcer_time_added.mp3,0,-1"
+				"OnHitMax" "@p@boss_thingy,$TakeDamage,5000,0.1,-1"
+				"OnHitMax" "@p@boss_thingy,$RemoveCond,73,0.1,-1"
+				"OnHitMax" "@p@boss_thingy,$RemoveCond,51,0,-1"
+				"OnHitMax" "@p@boss_thingy,$RemoveCond,7,0.1,-1"
+				"OnHitMax" "callateputa,enable,,0.1,-1"
+				"OnHitMax" "callateputa,disable,,0.2,-1"
+				"OnHitMax" "@p@boss_thingyRunScriptCodeself.AddCustomAttribute(`gesture speed increase`,1,-1)0-1"
+				"OnHitMax" "choosephase2,enable,,7,1"
+				"OnHitMax" "choosephase2,trigger,,7.1,1"
+				"OnHitMax" "choosephase1,disable,,7,1"
+				"OnHitMax" "pop_interface,ChangeBotAttributes,prehastycommons,7,1"
+				"OnHitMax" "enabler,trigger,,0,-1"
+				"OnHitMax" "enabler,enable,,0.1,-1"
+				"OnHitMax" "pop_interface,$PauseWavespawn,disablefor_ubergenerator,0,-1"
+            }
+			logic_relay
+			{
+				"targetname" "enabler"
+				"OnTrigger"  "bossattack_trigger,enable,,6,-1"
+				"OnTrigger"  "choosephase2,disable,,6,1"
+				"OnTrigger"  "pop_interface,ChangeBotAttributes,jumpingintothewater,6.1,-1"
+				"OnTrigger"  "bosstime2,playsound,,6.1,-1"
+				"OnTrigger"  "tf_gamerules,playvo,major_shocks.wav,2,-1"
+				"OnTrigger"  "tf_gamerules,playvo,ambient\alarms\razortrain_horn1.wav,4,-1"
+				"OnTrigger"  "tf_gamerules,playvo,major_shocks.wav,2,-1"
+				"OnTrigger"  "tf_gamerules,playvo,ambient\alarms\razortrain_horn1.wav,4,-1"
+				"OnTrigger"  "bignet,RunScriptCode,TextualTimer.Set(120),0,-1"
+				"OnTrigger" "tf_gamerules,PlayVO,vo\announcer_time_added.mp3,0,-1"
+				"startdisabled" "1"
+				"spawnflags" "2"
+			}
+			logic_relay //Should probably change a few of the sounds so it's not just the same as electrolysis
+			{
+				"targetname" "boss_intro"
+				"OnTrigger"	"tf_gamerules,PlayVO,mvm/giant_heavy/giant_heavy_entrance.wav,2.1,-1"
+				"OnTrigger"	"tf_gamerules,PlayVO,mvm/giant_heavy/giant_heavy_entrance.wav,2.1,-1"
+				"OnTrigger"	"tf_gamerules,PlayVO,npc/combine_gunship/ping_patrol.wav,2.9,-1"
+				"OnTrigger" "bignet,RunScriptCode,TextualTimer.Start(),10,1"
+				"OnTrigger" "tf_gamerules,PlayVO,Announcer.RoundEnds60seconds,10,1"
+			}
+			ambient_generic
+            {
+                "targetname"     "bosstime"
+                "health" "8"
+                "pitch" "100"
+                "spawnflags" "17"
+                "message" "#vs_architect.mp3"
+            }
+			ambient_generic
+            {
+                "targetname"     "bosstime2"
+                "health" "8"
+                "pitch" "100"
+                "spawnflags" "17"
+                "message" "#finalphase.mp3"
+            }
+		
+			game_text
+			{
+				"origin" "1984 1984 9999"
+				"targetname" "upper_text"
+				"message" "INCARNATION OF A TAMPERED LIFE CYCLE"
+				"x" "-1"
+				"y" "0.4"
+				"spawnflags" "1"
+				"effect" "2"
+				"channel" "2"
+				"color" "255 255 255"
+				"fxtime" "0.2"
+				"fadeout" "1"
+				//"fadein" "0"
+				"holdtime" "5"
+			}
+			game_text
+			{
+				"origin" "1208 2036 9999"
+				"targetname" "text_lower"
+				"message" "PLANNED OBSOLESCENCE"
+				"x" "-1"
+				"y" "0.45"
+				"channel" "1"
+				"spawnflags" "1"
+				"color" "155 155 255"
+				"fadein" "0.2"
+				"fadeout" "1"
+				"holdtime" "3.8"
+			}
+			logic_case
+			{
+				"targetname"	"RandomAttackChooser"
+				"OnCase01"	"SuckNBlow,Trigger,,0,-1"
+				"OnCase02"	"pop_interface,ChangeBotAttributes,IncreasingRocketBarrage,0,-1"
+				"OnCase03"	"CritRapidPhase,Trigger,,0,-1"
+				"OnCase04"	"ShotgunPhase,Trigger,,0,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"StartTheFight"
+				//"OnTrigger"	"RandomAttackChooser,PickRandomShuffle,,16,-1"
+				
+				"OnTrigger"  "hescomingtotickleyou,start,,0,1"
+				"OnTrigger"  "tf_gamerules,playvo,mvm\mvm_tele_deliver.wav,1,1"
+				"OnTrigger"  "hescomingtotickleyou2,start,,1,1"
+				"OnTrigger"  "tf_gamerules,playvo,mvm\mvm_tele_deliver.wav,2,1"
+				"OnTrigger"  "hescomingtotickleyou3,start,,2,1"
+				"OnTrigger"  "tf_gamerules,playvo,mvm\mvm_tele_deliver.wav,3,1"
+				"OnTrigger"  "hescomingtotickleyou4,start,,3,1"
+				"OnTrigger"  "tf_gamerules,playvo,mvm\mvm_tele_deliver.wav,4,1"
+				"OnTrigger"  "hescomingtotickleyou5,start,,4,1"
+				"OnTrigger"  "tf_gamerules,playvo,mvm\mvm_tele_deliver.wav,5,1"
+				"OnTrigger"  "hescomingtotickleyou6,start,,5,1"
+				"OnTrigger"  "tf_gamerules,playvo,major_shocks.wav,6,-1"
+				"OnTrigger"  "tf_gamerules,playvo,major_shocks.wav,6,-1"
+				"OnTrigger"  "playerrunscriptcodeScreenFade(null, 255, 255, 255, 128, 0.5, 0.1, 1)6-1"
+				"OnTrigger"  "goofyvortex*,kill,,6.1,1"
+				"OnTrigger"  "hescomingtotickleyou*,kill,,6.1,1"
+				"OnTrigger"	"boss_intro,Trigger,,4,-1"
+				"OnTrigger"	"bosstime,playsound,,0,-1"
+				"OnTrigger"	"upper_text,Display,,6,-1"
+				"OnTrigger"	"text_lower,Display,,8.1,-1"
+			}
+			info_particle_system
+			{
+				"targetname"   "goofyvortex"
+				"origin"       "1030 348 -184"
+				"effect_name"  "eyeboss_tp_vortex"
+				"start_active" "1"
+			}
+			info_particle_system
+			{
+				"targetname"   "goofyvortex"
+				"origin"       "1030 348 -184"
+				"effect_name"  "eyeboss_doorway_vortex"
+				"start_active" "1"
+			}
+			info_particle_system
+			{
+				"targetname"		"hescomingtotickleyou"
+				"effect_name"		"teleporter_mvm_bot_persist_core"
+				"flag_as_weather"	"0"
+				"start_active"		"0"
+				"origin"			"1030 348 -184"
+				"angles"			"-90 0 0"
+			}
+			info_particle_system
+			{
+				"targetname"		"hescomingtotickleyou2"
+				"effect_name"		"teleporter_mvm_bot_persist_core"
+				"flag_as_weather"	"0"
+				"start_active"		"0"
+				"origin"			"1030 348 -184"
+				"angles"			"-45 270 0"
+			}
+			info_particle_system
+			{
+				"targetname"		"hescomingtotickleyou3"
+				"effect_name"		"teleporter_mvm_bot_persist_core"
+				"flag_as_weather"	"0"
+				"start_active"		"0"
+				"origin"			"1030 348 -184"
+				"angles"			"36 178 163"
+			}
+			info_particle_system
+			{
+				"targetname"		"hescomingtotickleyou4"
+				"effect_name"		"teleporter_mvm_bot_persist_core"
+				"flag_as_weather"	"0"
+				"start_active"		"0"
+				"origin"			"1030 348 -184"
+				"angles"			"36 313 163"
+			}
+			info_particle_system
+			{
+				"targetname"		"hescomingtotickleyou5"
+				"effect_name"		"teleporter_mvm_bot_persist_core"
+				"flag_as_weather"	"0"
+				"start_active"		"0"
+				"origin"			"1030 348 -184"
+				"angles"			"-15 180 105"
+			}
+			info_particle_system
+			{
+				"targetname"		"hescomingtotickleyou6"
+				"effect_name"		"teleporter_mvm_bot_persist_core"
+				"flag_as_weather"	"0"
+				"start_active"		"0"
+				"origin"			"1030 348 -184"
+				"angles"			"11 -75 0"
+			}
+			logic_relay
+			{
+				"targetname"	"SuckNBlow"
+				//"OnTrigger"	"pop_interface,ChangeBotAttributes,SuckNBlow,0,-1"
+				//"OnTrigger"	"RandomAttackChooser,PickRandomShuffle,,4.6,-1"
+				"OnTrigger" "suck,Enable,,0.5,-1"
+				"OnTrigger" "blow,Enable,,4.6,-1"
+				"OnTrigger" "blow,Disable,,4.7,-1"
+				"OnTrigger" "suck,Disable,,4.5,-1"
+				"OnTrigger" "jumpcatapult,Enable,,4.5,-1"
+				"OnTrigger" "jumpcatapult,Disable,,4.6,-1"
+			}
+			// logic_relay
+			// {
+			// 	"targetname"	"HastySummoning"
+			// 	"OnTrigger"	"pop_interface,ChangeBotAttributes,HastySummons,0,-1"
+			// 	"OnTrigger"	"RandomAttackChooser,PickRandomShuffle,,6,-1"
+			// 	"OnTrigger" "backupteleporting,Enable,,3,-1"
+			// 	"OnTrigger" "backupteleporting,Disable,,3.1,-1"
+			// }
+			
+			trigger_teleport
+			{
+				"targetname"	"backupteleporting"
+				"StartDisabled" "1"
+				"target" "teleporttarget"
+				"filtername" "backuptag"
+				"origin"	"1380 -1024 -240"
+				"mins" "-1200 0 0"
+				"maxs" "0 350 256"
+				"spawnflags" "1"
+			}
+		}
+		trainwarningtemplate
+		{
+			logic_timer
+            {
+                "targetname" "mannpower_kill"
+                "RefireTime" "0.01"
+                "spawnflags" "0"
+                "UseRandomTime" "0"
+                "OnTimer" "item_powerup_rune,kill,,0,-1"
+            }
+			logic_relay
+			{
+				"targetname" "incomingpathswitch_right"
+				"OnTrigger"  "bombpath_holograms_clear_relay,trigger,,0,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,0,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,1,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,2,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,3,-1"
+				"OnTrigger"  "bombpath_2_relay,trigger,,4.5,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_warning.wav,4.5,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_warning.wav,4.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,4.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,7.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,10.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,13.5,-1"
+				"OnTrigger"  "bombpath_holograms_clear_relay,trigger,,25,-1"
+			}
+			logic_relay
+			{
+				"targetname" "incomingpathswitch_left"
+				"OnTrigger"  "bombpath_holograms_clear_relay,trigger,,0,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,0,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,1,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,2,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_cpoint_klaxon.wav,3,-1"
+				"OnTrigger"  "bombpath_1_relay,trigger,,4.5,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_warning.wav,4.5,-1"
+				"OnTrigger"  "tf_gamerules,PlayVO,mvm\mvm_warning.wav,4.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,4.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,7.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,10.5,-1"
+				"OnTrigger"  "bobchangeBITCH,display,,13.5,-1"
+				"OnTrigger"  "bombpath_holograms_clear_relay,trigger,,25,-1"
+			}
+			info_particle_system
+			{
+				"targetname"   "isogyou"
+				"parentname"   ""
+				"origin"       "5179 -1469 678"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			info_particle_system
+			{
+				"targetname"   "isogyou"
+				"parentname"   ""
+				"origin"       "3196 -1468 671"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			
+			info_particle_system
+			{
+				"targetname"   "isogyou"
+				"parentname"   ""
+				"origin"       "4092 -1487 698"
+				"effect_name"  "env_rain_001"
+				"start_active" "0"
+			}
+			game_text_tf // ditto
+			{
+				"background" 1
+				"display_to_team" 2
+				"icon" "ico_build"
+				"message" "The bomb path has changed!"
+				"targetname" "bobchangeBITCH"
+			}
+			logic_relay
+			{
+				"targetname"	"TrainWarn"
+				"OnTrigger"	"warningoftrainspawn,PlaySound,,0,-1"
+                "OnTrigger"	"warningoftrainspawn2,PlaySound,,8,-1"
+                "OnTrigger"	"warningoftrainspawn2,fadeout,5,10,-1"
+				"OnTrigger"	"warningoftrainspawn*,StopSound,,13,-1"
+			}
+			logic_relay
+			{
+				"targetname"	"TrainWarnFaster"
+				"OnTrigger"	"warningoftrainspawn,PlaySound,,0,-1"
+				"OnTrigger"	"warningoftrainspawn,fadeout,2,3,-1"
+                "OnTrigger"	"warningoftrainspawn2,PlaySound,,4,-1"
+                "OnTrigger"	"warningoftrainspawn2,fadeout,4,3,-1"
+				"OnTrigger"	"warningoftrainspawn*,StopSound,,7.1,-1"
+			}
+			ambient_generic
+            {
+                "targetname"     "warningoftrainspawn"
+                "health" "10"
+                "pitch" "100"
+                "spawnflags" "17"
+                "message" "ambient/alarms/train_horn_distant1.wav"
+            }
+			ambient_generic
+            {
+                "targetname"     "warningoftrainspawn"
+                "health" "10"
+                "pitch" "100"
+                "spawnflags" "17"
+                "message" "ambient/alarms/train_horn_distant1.wav"
+            }
+            ambient_generic
+            {
+                "targetname"     "warningoftrainspawn2"
+                "health" "10"
+                "pitch" "100"
+                "spawnflags" "17"
+                "message" "ambient\alarms\train_horn2.wav"
+            }
+			ambient_generic
+            {
+                "targetname"     "warningoftrainspawn2"
+                "health" "10"
+                "pitch" "100"
+                "spawnflags" "17"
+                "message" "ambient\alarms\train_horn2.wav"
+            }
+		}
+	}
+	
+	SpawnTemplate	MissionName
+	SpawnTemplate	trainwarningtemplate
+	
+	Templates
+	{
+		BigFunnyBossMan
+		{
+			Class	Soldier
+			Name	"Planned Obsolescence"
+			ClassIcon	soldier_gib_lite_giant
+			Skill Expert
+			Health 120000
+			Scale 1.8
+			Attributes	"MiniBoss"
+			Attributes	"UseBossHealthBar"
+			WeaponRestrictions	MeleeOnly
+			Attributes SpawnWithFullCharge
+			AlwaysGLow 1
+			UseMeleeThreatPrioritization 1
+			UseCustomModel "models\bots\soldier_boss\bot_soldier_boss_gibby.mdl"
+			SpawnTemplate	bossattachments
+			CharacterAttributes
+			{
+				"move speed bonus"	0.55
+				"damage force reduction" 0.1
+				"airblast vulnerability multiplier" 0.5
+				"airblast vertical vulnerability multiplier" 0.3
+				"rage giving scale"	0.2
+				"override footstep sound set" 2
+				"cancel falling damage" 1
+//				"cannot pick up intelligence" 1
+			}
+			WeaponResist
+			{
+				"TF_WEAPON_MINIGUN"	0.7
+			}
+			FireInput
+			{
+				Target "!self"
+				Action "$SetLocalOrigin"
+				Param  "1030 348 -184"
+				Delay  -1
+				Cooldown 99999
+			}
+			FireInput //shake
+			{
+				Target "!self"
+				Action "runscriptcode"
+				Param "ScreenShake(self.GetOrigin(), 3, 8, 0.5, 750, 0, true)"
+				Delay -1
+				Cooldown 0.5
+                Repeats 0
+            }
+			// FireInput
+			// {
+			// 	Target "StartTheFight"
+			// 	Action Trigger
+			// 	Delay 0
+			// 	Cooldown 0
+			// 	Repeats 1
+			// }
+			ChangeAttributes
+			{
+				Name increasingrocketbarrage
+				Delay 0
+				Repeats 1
+				Cooldown 9999
+			}
+			ChangeAttributes
+			{
+				Name ubergeneratortutorial
+				Delay 0
+				Repeats 1
+				Cooldown 9999
+				IfHealthBelow 110000
+			}
+			ChangeAttributes
+			{
+				Name ubergeneratortutorial_serious
+				Delay 0
+				Repeats 1
+				Cooldown 9999
+				IfHealthBelow 80000
+			}
+			ChangeAttributes
+			{
+				Name ubergeneratortutorial_final
+				Delay 0
+				Repeats 1
+				Cooldown 9999
+				IfHealthBelow 40000
+			}
+			EventChangeAttributes
+			{
+				ubergeneratortutorial_final
+				{
+					FireInput
+					{
+						Target "pop_interface"
+						Action "$ResumeWavespawn"
+						Param "disablefor_ubergenerator"
+						Delay 0
+						Repeats 1
+					}
+					FireInput
+					{
+						Target "randomizedspawnsforgenerators_final"
+						Action "PickRandomShuffle"
+						Delay  3
+						Repeats 5
+						Cooldown 1
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "PLayVO"
+						Param "vo\mvm\mght\soldier_mvm_m_cheers05.mp3"
+						Delay  1
+						Repeats 1
+						Cooldown 999999
+					}
+					CharacterAttributes
+					{
+						"no_jump" 1
+						"no_attack" 1
+						"move speed bonus" 0.001
+						"taunt attack time mult" 5
+						"healing received bonus" 14
+					}
+					Taunt    //Taunt periodically
+					{
+						Delay 0.1 //Time before the first taunt starts (Default: 10)
+						Cooldown 999999 //Time between each taunt (Default: 10)
+						Repeats 0 //How many times the bot should taunt in total (Default: 0 - Infinite)
+						Duration 99999 //Duration of a looping taunt (Default: 0.1)
+						Name "Taunt: Cheers!" //If set, uses this item taunt instead of default
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 0 // Attribute value
+						Delay 0 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 1 // Attribute value
+						Delay 0.2 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 0 // Attribute value
+						Delay 3.2 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddCond
+					{
+						Index 51
+						Delay 2
+					}
+					AddCond
+					{
+						Index 73
+						Delay 2
+					}
+					AddCond
+					{
+						Index 7
+						Delay 3
+						Duration 99
+					}
+				}
+				ubergeneratortutorial_serious
+				{
+					FireInput
+					{
+						Target "pop_interface"
+						Action "$ResumeWavespawn"
+						Param "disablefor_ubergenerator"
+						Delay 0
+						Repeats 1
+					}
+					FireInput
+					{
+						Target "randomizedspawnsforgenerators"
+						Action "PickRandomShuffle"
+						Delay  3
+						Repeats 3
+						Cooldown 1
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "PLayVO"
+						Param "vo\mvm\mght\soldier_mvm_m_cheers05.mp3"
+						Delay  1
+						Repeats 1
+						Cooldown 999999
+					}
+					CharacterAttributes
+					{
+						"no_jump" 1
+						"no_attack" 1
+						"move speed bonus" 0.001
+						"taunt attack time mult" 5
+						"healing received bonus" 11
+					}
+					Taunt    //Taunt periodically
+					{
+						Delay 0.1 //Time before the first taunt starts (Default: 10)
+						Cooldown 999999 //Time between each taunt (Default: 10)
+						Repeats 0 //How many times the bot should taunt in total (Default: 0 - Infinite)
+						Duration 99999 //Duration of a looping taunt (Default: 0.1)
+						Name "Taunt: Cheers!" //If set, uses this item taunt instead of default
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 0 // Attribute value
+						Delay 0 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 1 // Attribute value
+						Delay 0.2 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 0 // Attribute value
+						Delay 3.2 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddCond
+					{
+						Index 51
+						Delay 2
+					}
+					AddCond
+					{
+						Index 73
+						Delay 2
+					}
+					AddCond
+					{
+						Index 7
+						Delay 3
+						Duration 99
+					}
+				}
+				ubergeneratortutorial
+				{
+					FireInput
+					{
+						Target "ubergeneratortutorial_template"
+						Action "ForceSpawn"
+						Delay  3
+						Repeats 1
+						Cooldown 999999
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "PLayVO"
+						Param "vo\mvm\mght\soldier_mvm_m_cheers05.mp3"
+						Delay  1
+						Repeats 1
+						Cooldown 999999
+					}
+					CharacterAttributes
+					{
+						"no_jump" 1
+						"no_attack" 1
+						"move speed bonus" 0.001
+						"taunt attack time mult" 5
+						"healing received bonus" 8
+					}
+					Taunt    //Taunt periodically
+					{
+						Delay 0.1 //Time before the first taunt starts (Default: 10)
+						Cooldown 999999 //Time between each taunt (Default: 10)
+						Repeats 0 //How many times the bot should taunt in total (Default: 0 - Infinite)
+						Duration 99999 //Duration of a looping taunt (Default: 0.1)
+						Name "Taunt: Cheers!" //If set, uses this item taunt instead of default
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 0 // Attribute value
+						Delay 0 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 1 // Attribute value
+						Delay 0.2 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "gesture speed increase" // Attribute name
+						Value 0 // Attribute value
+						Delay 3.2 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddCond
+					{
+						Index 51
+						Delay 2
+					}
+					AddCond
+					{
+						Index 73
+						Delay 2
+					}
+					AddCond
+					{
+						Index 7
+						Delay 3
+						Duration 99
+					}
+				}
+				specialattackjump
+                {
+					WeaponRestrictions PrimaryOnly
+					Item "the direct hit"
+					AimAt Feet
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 		soldier_homing_direct_burst_giant
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					ItemAttributes
+					{
+						ItemName "the direct hit"
+						"spread angle pattern" "0 25 0|25 0 0|0 -25 0|-25 0 0|0 0 0"
+						"mult projectile count" 5
+						"ignores other projectiles" 1
+                        "projectile speed decreased" 0.3
+                        "mod projectile heat seek power" 60
+                        "mod projectile heat aim error" 360
+                        "mod projectile heat aim time" 0.9
+						"projectile trail particle" "halloween_rockettrail"
+						"faster reload rate" -1
+						"fire rate bonus" 1.35
+					}
+					AddCond
+					{
+						Index 36
+						Duration 10
+					}
+                    AddAttribute
+                    {
+                        Item "player"
+                        Name "no_jump"
+                        Value 1
+                        Delay 0
+                        Cooldown 20
+                    }
+                    AddAttribute
+                    {
+                        Item "player"
+                        Name "no_attack"
+                        Value 1
+                        Delay 0
+						Cooldown 20
+                    }
+					AddAttribute
+                    {
+                        Item "player"
+                        Name "no_attack"
+                        Value 0
+                        Delay 5
+						Cooldown 20
+                    }
+                    FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_laughlong01.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_laughlong01.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "!self"
+                        Action "$PlaySequence"
+                        Param  "taunt_unleashed_rage_soldier"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "jumpattack"
+                        Action "Trigger"
+                        Delay 2.5
+                        Repeats 1
+                        Cooldown 99
+                    }
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 12
+                        Repeats 0
+                        Cooldown 12.1
+                    }
+                    FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 10
+                        Repeats 0
+                        Cooldown 12.1
+                    }
+                }
+				jumpingintothewater
+				{
+					WeaponRestrictions MeleeOnly
+					Item "The Neon Annihilator"
+					CharacterAttributes
+					{
+						"displace touched enemies" 1
+						"move speed bonus" 3
+						"mult stun resistance" 0
+					}
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 	pyro_neon_giant
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					InterruptAction
+                    {
+                        Target "3529 -1509 -126"
+                        Duration 0.1
+                        Delay 0.1
+                        Cooldown 1
+                        Repeats 1
+                        WaitUntilDone 1
+                        Distance 50
+						OnDoneChangeAttributes jumpingintothewaternow
+                    }
+				}
+				jumpingintothewaternow
+				{
+					Item "The Neon Annihilator"
+					WeaponRestrictions MeleeOnly
+					AddCond
+					{
+						Index 130
+						Duration 8
+					}
+					AddCond
+					{
+						Index 51
+						Duration 8
+					}
+					FireInput
+					{
+						Target "pop_interface"
+						Action "$ResumeWavespawn"
+						Param  "forthesplashattack"
+						Delay  4.5
+						Repeats 1
+					}
+					FireInput
+					{
+						Target "TrainWarnFaster"
+						Action "Trigger"
+						Delay  0
+						Repeats 1
+					}
+					CharacterAttributes
+					{
+						"no_attack" 1
+						"cancel falling damage" 1
+						"move speed bonus" 0.0001
+						"dmg from melee increased" 0.5
+						"dmg from ranged reduced" 0.3
+						"mult stun resistance" 0
+						"displace touched enemies" 1
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "playvo"
+						Param  "mvm/mvm_deploy_giant.wav"
+						Delay  0
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "playvo"
+						Param  "vo\mvm\mght\soldier_mvm_m_directhittaunt02.mp3"
+						Delay  0
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+					{ // this makes the bot move forward in the air
+						Target "watersplashes"
+						Action "trigger"
+						Delay 3.4
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "playvo"
+						Param  "woter.mp3"
+						Delay  3.1
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+					{ // this makes the bot move forward in the air
+						Target "!self"
+						Action "RunScriptCode"
+						Param "self.ApplyAbsVelocityImpulse(Vector(0,-175,1300))"
+						Delay 0.73
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+					{ // this makes the bot move forward in the air
+						Target "todisable"
+						Action "disable"
+						Delay 3
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+					{ // this makes the bot move forward in the air
+						Target "todisable"
+						Action "disable"
+						Delay 6.5
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+                    {
+                        Target "!self"
+                        Action "$PlaySequence"
+                        Param  "primary_fall_stomp_A"
+                        Delay  2.15
+						Repeats 1
+                        Cooldown 99
+                    }
+					FireInput
+                    {
+                        Target "!self"
+                        Action "$PlaySequence"
+                        Param  "taunt_flip_success_receiver"
+                        Delay  0
+						Repeats 1
+                        Cooldown 99
+                    }
+					FireInput
+                    {
+                        Target "!self"
+                        Action "$PlaySequence"
+                        Param  "taunt_flip_success_receiver"
+                        Delay  4.5
+						Repeats 1
+                        Cooldown 99
+                    }
+					FireInput
+					{ // this makes the bot move forward in the air
+						Target "!self"
+						Action "RunScriptCode"
+						Param "self.ApplyAbsVelocityImpulse(Vector(0,700,2000))"
+						Delay 5.2
+						Repeats 1
+						Cooldown 99
+					}
+					FireInput
+                    {
+                        Target "!self"
+                        Action "$PlaySequence"
+                        Param  "run_melee"
+                        Delay  7.6
+						Repeats 1
+                        Cooldown 7.7
+                    }
+					ChangeAttributes
+					{
+						Name "cantbelieveihavetodothis"
+						Delay 8
+						Repeats 1
+						Cooldown 8.1
+					}
+					FireInput
+					{
+						Target "pop_interface"
+						Action "$PauseWavespawn"
+						Param  "forthesplashattack"
+						Delay  4.9
+						Repeats 1
+					}
+				}
+				cantbelieveihavetodothis
+				{
+					WeaponRestrictions MeleeOnly
+					Item "The Neon Annihilator"
+					CharacterAttributes
+					{
+						"displace touched enemies" 1
+						"move speed bonus" 0.8
+						"melee range multiplier" 1.75
+					}
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 10
+                        Repeats 0
+                        Cooldown 10.1
+                    }
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 9
+                        Repeats 0
+                        Cooldown 10.1
+                    }
+				}
+				loosecannonscatter
+				{
+					Item "The Loose Cannon"
+					WeaponRestrictions PrimaryOnly
+					
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 		soldier_airstrike
+						Delay 0.1
+						Cooldown 0
+						Repeats 1
+					}
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 10
+                        Repeats 0
+                        Cooldown 10.1
+                    }
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 8
+                        Repeats 0
+                        Cooldown 10.1
+                    }
+					ItemAttributes
+					{
+						ItemName "The Loose Cannon"
+						"hand scale" 2.0
+						"fire rate bonus" 2.75
+						"faster reload rate" -1
+						"grenade launcher mortar mode" 0
+						"mult projectile scale" 2.15
+						"damage bonus" 2
+						"Blast radius increased" 2
+						"projectile no deflect" 1
+						"custom item model" "models/workshop/weapons/c_models/c_blackbox/c_blackbox.mdl"
+					}
+					ShootTemplate
+					{
+						Name scatter_rockets_base
+						AttachToProjectile 1
+						ItemName "The Loose Cannon"
+					}
+					
+				}
+				sucknblow
+				{
+					Item	"tf_weapon_shovel"
+					WeaponRestrictions	MeleeOnly
+					FireInput
+					{
+						Target "SuckNBlow"
+						Action "trigger"
+						Delay  0.1
+					}
+					Taunt    //Taunt periodically
+					{
+						Delay 0.1 //Time before the first taunt starts (Default: 10)
+						Cooldown 0 //Time between each taunt (Default: 10)
+						Repeats 0 //How many times the bot should taunt in total (Default: 0 - Infinite)
+						Duration 1 //Duration of a looping taunt (Default: 0.1)
+						Name "Taunt: Can It!" //If set, uses this item taunt instead of default
+					}
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 	trash_meme
+						Delay 0.1
+						Cooldown 0
+						Repeats 1
+					}
+					CharacterAttributes
+					{
+						"move speed bonus"	0.4
+						"damage force reduction" 0.0
+						"airblast vulnerability multiplier" 0.
+						"airblast vertical vulnerability multiplier" 0.0
+						"rage giving scale"	0.2
+						"override footstep sound set" 2
+//						"cannot pick up intelligence" 1
+						"dmg from melee increased" 0.5
+					}
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 5
+                        Repeats 0
+                        Cooldown 5.1
+                    }
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 5
+                        Repeats 0
+                        Cooldown 5.1
+                    }
+				}
+				prehastycommons
+				{
+					Item	"tf_weapon_shovel"
+					WeaponRestrictions	MeleeOnly
+					CharacterAttributes
+					{
+						"displace touched enemies" 1
+						"move speed bonus" 2
+						"mult stun resistance" 0
+					}
+					InterruptAction
+                    {
+                        Target "2379 -509 -255"
+                        Duration 0.1
+                        Delay 0.1
+                        Cooldown 1
+                        Repeats 1
+                        WaitUntilDone 1
+                        Distance 25
+						OnDoneChangeAttributes hastysummons
+                    }
+				}
+				hastysummons
+				{
+					Item	"TF_WEAPON_ROCKETLAUNCHER"
+					Item 	"The Concheror"
+					WeaponRestrictions	PrimaryOnly
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 	soldier_conch_burstfire_yoovy
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 20
+                        Repeats 0
+                        Cooldown 20.1
+                    }
+					WeaponSwitch
+					{
+						Delay 0
+						Cooldown 99
+						Repeats 1
+						Type "Secondary"
+					}
+					WeaponSwitch
+					{
+						Delay 7
+						Cooldown 99
+						Repeats 1
+						Type "Primary"
+					}
+					FireInput
+					{
+						Target "pop_interface"
+						Action "$ResumeWavespawn"
+						Param  "disableformidboss"
+						Delay  4.8
+						Repeats 1
+					}
+					FireInput
+					{
+						Target "pop_interface"
+						Action "$PauseWavespawn"
+						Param  "disableformidboss"
+						Delay  5.1
+						Repeats 1
+					}
+					FireInput
+					{
+						Target "TrainWarnFaster"
+						Action "trigger"
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					Taunt    //Taunt periodically
+					{
+						Delay 4 //Time before the first taunt starts (Default: 10)
+						Cooldown 99 //Time between each taunt (Default: 10)
+						Repeats 1 //How many times the bot should taunt in total (Default: 0 - Infinite)
+						Duration 4 //Duration of a looping taunt (Default: 0.1)
+						Name "Taunt: Star-Spangled Strategy" //If set, uses this item taunt instead of default
+					}
+					RemoveAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "no_attack" // Attribute name
+						Delay 7 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					AddAttribute   
+					{
+						Item "player" // Item name to which add the attribute, or Player for player attribute, or Active for active weapon
+						Name "move speed bonus" // Attribute name
+						Value 0.5 // Attribute value
+						Delay 7 //Delay before adding the attribute
+						Cooldown 99 //Cooldown between adding attributes
+						Repeats 99 //How many times should the attribute be added (Matters only if it was previously removed)
+					}
+					ItemAttributes
+					{
+						ItemName "TF_WEAPON_ROCKETLAUNCHER"
+						"damage bonus" 2.0
+						"faster reload rate" 0.4
+						"fire rate bonus" 0.2
+						"clip size upgrade atomic" 5.0
+					}
+					CharacterAttributes
+					{
+						"move speed bonus"	0.0001
+						"rage giving scale"	0.2
+						"damage force reduction" 0.0
+						"airblast vulnerability multiplier" 0.0
+						"airblast vertical vulnerability multiplier" 0.0
+						"override footstep sound set" 2
+//						"cannot pick up intelligence" 1
+						"dmg from melee increased" 0.5
+						"dmg from ranged reduced" 0.3
+						"no_jump" 1
+						"hold fire until full reload" 1
+						"displace touched enemies" 1
+						"increase buff duration" 9
+					}
+				}
+				IncreasingRocketBarrage
+				{
+					WeaponRestrictions	PrimaryOnly
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 	soldier_rocketrain_giant
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					Attributes	HoldFireUntilFullReload
+					Item "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
+					ItemAttributes
+					{
+						ItemName "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
+						"spread angle pattern" "0 10 0|10 0 0|0 -10 0|-10 0 0|-5 5 0|-5 -5 0|5 5 0|5 -5 0|5 5 0|5 -5 0|-5 -5 0|-5 5 0|10 -10 0|10 10 0|-10 10 0|-10 -10 0"
+						"projectile speed decreased" 0.6
+						"paintkit_proto_def_index" 431 //Blackout
+						"clip size upgrade atomic" 26
+						"set_item_texture_wear" 0
+						"mult projectile count" 8
+						"ignores other projectiles" 1
+						"faster reload rate" 0.65
+						"fire rate bonus" 1.2
+					}
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 9
+                        Repeats 0
+                        Cooldown 9.1
+                    }
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 8
+                        Repeats 0
+                        Cooldown 9.1
+                    }
+				}
+				normalcritrapid
+				{
+					Item	"The Liberty Launcher"
+					WeaponRestrictions	PrimaryOnly
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 	soldier_spammer
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					CharacterAttributes
+					{
+						"move speed bonus"	0.4
+						"damage force reduction" 0.1
+						"airblast vulnerability multiplier" 0.5
+						"airblast vertical vulnerability multiplier" 0.3
+						"rage giving scale"	0.2
+						"override footstep sound set" 2
+						"Projectile speed increased HIDDEN" 0.6
+//						"cannot pick up intelligence" 1
+						"fire rate penalty" 0.2
+						"Reload time decreased" 0.2
+						"clip size bonus" 0.25
+						"dmg from melee increased" 1
+						"damage bonus" 1.5
+					}
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 7
+                        Repeats 0
+                        Cooldown 7.1
+                    }
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 6.5
+                        Repeats 0
+                        Cooldown 7.1
+                    }
+				}
+				healingshotgunrapid
+				{
+					Item	"tf_weapon_shotgun_soldier"
+					WeaponRestrictions	SecondaryOnly
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 		heavy_shotgun_burst_lite
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					CharacterAttributes
+					{
+						"move speed bonus"	0.4
+						"damage force reduction" 0.1
+						"airblast vulnerability multiplier" 0.5
+						"airblast vertical vulnerability multiplier" 0.3
+						"rage giving scale"	0.2
+						"override footstep sound set" 2
+//						"cannot pick up intelligence" 1
+						"fire rate penalty" 0.1
+						"Reload time decreased" 0.10
+						"clip size bonus" 2
+						"hold fire until full reload" 1
+						"dmg from melee increased" 1
+					}
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 8
+                        Repeats 0
+                        Cooldown 8.1
+                    }
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 7
+                        Repeats 0
+                        Cooldown 8.1
+                    }
+				}
+				nuker
+				{
+					Item "The Black Box"
+					WeaponRestrictions PrimaryOnly
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 		soldier_nuke2
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					
+					ItemAttributes
+					{
+						ItemName "The Black Box"
+						"damage bonus" 3
+						"damage causes airblast" 1
+						"fire rate bonus" 2.5
+						"use large smoke explosion" 1
+						"blast radius increased" 2
+						"clip size penalty" 0.25
+						"faster reload rate" -1
+						"Projectile speed increased" 0.7
+						// "custom projectile model" 
+						"custom impact sound" "misc/doomsday_missile_explosion.wav"
+						"projectile trail particle" "spell_fireball_small_red"
+						"explosion particle" "mvm_hatch_destroy"
+						"hand scale" 1.7
+						"custom kill icon" "megaton"
+						// "mult projectile scale" 1.5
+					}
+					ShootTemplate
+					{
+						Name itscalledflairsir
+						OriginalItemName "The Black Box"
+						AttachToProjectile 1
+					}
+					FireInput
+                    {
+                        Target "attackchooser"
+                        Action "Trigger"
+                        Delay 8
+                        Repeats 0
+                        Cooldown 8.1
+                    }
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 7
+                        Repeats 0
+                        Cooldown 8.1
+                    }
+				}
+				spiralrocketattackofdoom
+				{
+					WeaponRestrictions	PrimaryOnly
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 	soldier_rocketrain_giant
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_directhittaunt04.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_directhittaunt04.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+					Item "TF_WEAPON_ROCKETLAUNCHER"
+					ItemAttributes
+					{
+						ItemName "TF_WEAPON_ROCKETLAUNCHER"
+						"projectile spread angle penalty" 5
+						"projectile speed decreased" 0.6
+						// "projectile spread angle penalty" 5
+						"faster reload rate" -1
+						"damage bonus" 1.2
+						"faster reload rate" -0.5
+						"fire rate bonus" 0.1
+					}
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 6
+                        Repeats 0
+                        Cooldown 9.1
+                    }
+				}
+				nukermultiple
+				{
+					AimOffset "0 0 700"
+					Item "The Black Box"
+					Attributes SuppressFire
+					WeaponRestrictions PrimaryOnly
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 		soldier_nuke2
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_autodejectedtie02.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_autodejectedtie02.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+					FireWeapon    //Periodically fires weapon
+					{
+						Delay 2.5 //Time before the first fire input starts (Default: 10)
+						Cooldown 1 //Time between each fire input (Default: 10)
+						Repeats 5 //How many times should bot use the fire input in total (Default: 0 - Infinite)
+						Duration 0.1 //How long should the button be pressed (Default: 0.1)
+						Type "Primary"
+					}
+					ItemAttributes
+					{
+						ItemName "The Black Box"
+						"damage bonus" 3
+						"damage causes airblast" 1
+						"fire rate bonus" 0.5
+						"use large smoke explosion" 1
+						"projectile gravity" 900
+						"blast radius increased" 2
+						"clip size penalty" 0.25
+						"faster reload rate" -1
+						"Projectile speed increased" 0.7
+						// "custom projectile model" 
+						"custom impact sound" "misc/doomsday_missile_explosion.wav"
+						"projectile trail particle" "spell_fireball_small_red"
+						"projectile sound" "weapons/mortar/mortar_shell_incomming1.wav"
+						"explosion particle" "mvm_hatch_destroy"
+						"hand scale" 1.7
+						"custom kill icon" "megaton"
+						// "mult projectile scale" 1.5
+					}
+					ShootTemplate
+					{
+						Name itscalledflairsir
+						OriginalItemName "The Black Box"
+						AttachToProjectile 1
+					}
+					FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 8
+                        Repeats 0
+                        Cooldown 8.1
+                    }
+				}
+				specialattackjump2
+                {
+					WeaponRestrictions PrimaryOnly
+					Item "the direct hit"
+					Attributes SuppressFire
+					AimAt Feet
+					FireInput
+					{
+						Target player
+						Action $SetProp$m_iszClassIcon
+						Param 		soldier_homing_direct_burst_giant
+						Delay 0
+						Cooldown 0
+						Repeats 1
+					}
+					FireWeapon    //Periodically fires weapon
+					{
+						Delay 4.5 //Time before the first fire input starts (Default: 10)
+						Cooldown 3 //Time between each fire input (Default: 10)
+						Repeats 3 //How many times should bot use the fire input in total (Default: 0 - Infinite)
+						Duration 0.1 //How long should the button be pressed (Default: 0.1)
+						Type "Primary"
+					}
+					FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_battlecry05.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\soldier_mvm_m_battlecry05.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+					ItemAttributes
+					{
+						ItemName "the direct hit"
+						"spread angle pattern" "0 25 0|25 0 0|0 -25 0|-25 0 0|0 0 0|15 15 0|15 0 0|0 -15 0|-15 15 0|"
+						"mult projectile count" 9
+						"ignores other projectiles" 1
+                        "projectile speed decreased" 0.3
+                        "mod projectile heat seek power" 60
+                        "mod projectile heat aim error" 360
+                        "mod projectile heat aim time" 0.9
+						"projectile trail particle" "halloween_rockettrail"
+						"faster reload rate" -1
+						"fire rate bonus" 1.35
+					}
+					AddCond
+					{
+						Index 36
+						Duration 10
+					}
+                    AddAttribute
+                    {
+                        Item "player"
+                        Name "no_jump"
+                        Value 1
+                        Delay 0
+                        Cooldown 20
+                    }
+                    FireInput
+                    {
+                        Target "!self"
+                        Action "$PlaySequence"
+                        Param  "taunt_unleashed_rage_soldier"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "jumpattack"
+                        Action "Trigger"
+                        Delay 2.5
+                        Repeats 3
+                        Cooldown 3
+                    }
+                    FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 12
+                        Repeats 0
+                        Cooldown 12.1
+                    }
+                }
+				totheskiesandairstrike
+				{
+					Item "The Original"
+					WeaponRestrictions PrimaryOnly
+					Attributes SuppressFire
+					FireWeapon    //Periodically fires weapon
+					{
+						Delay 2.8 //Time before the first fire input starts (Default: 10)
+						Cooldown 4 //Time between each fire input (Default: 10)
+						Repeats 3 //How many times should bot use the fire input in total (Default: 0 - Infinite)
+						Duration 0.15 //How long should the button be pressed (Default: 0.1)
+						Type "Primary"
+					}
+					FireInput
+					{ // this makes the bot move forward in the air
+						Target "!self"
+						Action "RunScriptCode"
+						Param "self.ApplyAbsVelocityImpulse(Vector(0,0,1300))"
+						Delay 2
+						Repeats 3
+						Cooldown 4
+					}
+					VoiceCommand
+					{
+						Delay 1.7
+						Cooldown 99
+						Repeats 1
+						Type "Cheers"
+                    }
+					FireInput
+					{ // this makes the bot move forward in the air
+						Target "player"
+						Action "$PlaySoundToSelf"
+						Param "=140|misc\halloween\spell_meteor_cast.wav"
+						Delay 2
+						Repeats 3
+						Cooldown 4
+					}
+					FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\taunts\soldier_mvm_m_taunts05.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+                    FireInput
+                    {
+                        Target "player"
+                        Action "$playsoundtoself"
+                        Param  "vo\mvm\mght\taunts\soldier_mvm_m_taunts05.mp3"
+                        Delay  0
+						 Repeats 1
+                        Cooldown 99
+                    }
+					HomingRockets   
+					{
+						IgnoreDisguisedSpies 1 
+						IgnoreStealthedSpies 1 
+						RocketSpeed 0.1
+						TurnPower 360
+						MaxAimError 360
+						AimTime 2.5
+						Acceleration 9999
+						AccelerationTime 9999
+						AccelerationStartTime 2.5
+					}
+					ItemAttributes
+					{
+						ItemName "The Original"
+						"add cond when active" 36
+						"clip size upgrade atomic" 12
+						"fire rate bonus" 0.001
+						"damage bonus" 0.7
+						"faster reload rate" -1
+						"projectile spread angle penalty" 180
+						"ignores other projectiles" 1
+						"projectile trail particle" "halloween_rockettrail"
+						"projectile no deflect" 1
+					}
+					 FireInput
+                    {
+                        Target "bossattack_trigger"
+                        Action "Trigger"
+                        Delay 12
+                        Repeats 0
+                        Cooldown 12.1
+                    }
+				}
+			}
+		}
+		GiantHeavyDeflector
+		{
+			Class Heavyweapons
+			Name "Giant Deflector Heavy"
+			ClassIcon heavy_deflector
+			Skill Expert
+			Health 5000
+			Scale 1.8
+			WeaponRestrictions PrimaryOnly
+			Attributes MiniBoss
+			Item	"The U-clank-a"
+			CharacterAttributes
+			{
+				"move speed bonus"	0.4
+				"damage force reduction" 0.3
+				"airblast vulnerability multiplier" 0.4
+				"airblast vertical vulnerability multiplier" 0.1
+				"rage giving scale"	0.9
+				"override footstep sound set" 2
+				"damage bonus"	1.2
+				"attack projectiles" 2
+			}
+		}
+		GiantUberMedic
+		{
+			Class Medic
+			Name "Giant Uber Medic"
+			ClassIcon medic_uber_giant
+			Skill Expert
+			Health 4500
+			Attributes SpawnWithFullCharge
+			WeaponRestrictions SecondaryOnly
+			Attributes MiniBoss
+			CharacterAttributes
+			{
+				"move speed bonus"	0.5
+				"damage force reduction" 0.6
+				"airblast vulnerability multiplier" 0.6
+				"heal rate bonus" 200 // only works on mediguns that have this attribute ie quickfix
+				"bot medic uber health threshold" 1000
+				"bot medic uber deploy delay duration" 2
+			}
+		}
+		GiantKritzMedic
+		{
+			Class Medic
+			Name "Giant Kritz Medic"
+			ClassIcon medic_kritz
+			Skill Expert
+			Health 4500
+			Attributes SpawnWithFullCharge
+			WeaponRestrictions SecondaryOnly
+			Attributes MiniBoss
+			Item	"The Kritzkrieg"
+			CharacterAttributes
+			{
+				"uber duration bonus" 999.0
+				"move speed bonus"	0.5
+				"damage force reduction" 0.6
+				"bot medic uber health threshold" 100000
+				"airblast vulnerability multiplier" 0.6
+				"heal rate bonus" 200 // only works on mediguns that have this attribute ie quickfix
+			}
+		}
+		GiantShieldMedic
+		{
+			Class Medic
+			Name "Giant Shield Medic"
+			ClassIcon medic_shield_lite
+			Skill Expert
+			Health 4500
+			Attributes SpawnWithFullCharge
+			WeaponRestrictions SecondaryOnly
+			Attributes MiniBoss
+			Attributes ProjectileShield
+			Attributes SpawnWithFullCharge
+			FireWeapon
+            {
+				Delay 1 //Time before the first fire input starts (Default: 10)
+				Cooldown 3 //Time between each fire input (Default: 10)
+				Repeats 0 //How many times should bot use the fire input in total (Default: 0 - Infinite)
+				//IfSeeTarget 1 //When set to 1, this task activates only when the bot can see the target player (Default 0 - Always activate)
+				Duration 0.5 //How long should the button be pressed (Default: 0.1)
+				Type "Special"
+			}
+			CharacterAttributes
+			{
+				"bot medic uber deploy delay duration" 999999
+				"generate rage on heal" 2
+				"heal rate bonus" 2
+				"move speed bonus"	0.5
+				"damage force reduction" 0.6
+				"airblast vulnerability multiplier" 0.6
+				"heal rate bonus" 200 // only works on mediguns that have this attribute ie quickfix
+				"increase buff duration"	999.0
+			}
+		}
+		GiantBisonRapid
+		{
+			Class	Soldier
+			Skill	Expert
+			Health 3800
+			ClassIcon	soldier_bison_rapidfire
+			Attributes	"MiniBoss"
+			Name	"Giant Rapidfire Bison Soldier"
+			WeaponRestrictions	SecondaryOnly
+			Item	"The Righteous Bison"
+			CharacterAttributes
+			{
+				"fire rate bonus" 0.1
+				"reload time decreased" 0.1
+				"move speed bonus"	0.5
+				"damage force reduction" 0.6
+				"airblast vulnerability multiplier" 0.6
+			}
+		}
+		GiantPyroFury
+		{
+			Class	Pyro
+			Skill	Expert
+			Health 3800
+			ClassIcon	Pyro_dragon_fury
+			Attributes	"MiniBoss"
+			Name	"Giant Dragon's Fury Pyro"
+			WeaponRestrictions	PrimaryOnly
+			Item	"The Dragon's Fury"
+			CharacterAttributes
+			{
+				"fire rate bonus" 0.8
+				"move speed bonus"	0.5
+				"damage force reduction" 0.6
+				"airblast vulnerability multiplier" 0.6
+			}
+		}
+		ConchScout
+		{
+			Class	Scout
+			Health	125
+			ClassIcon	scout_conch_lite
+			Name	"Concheror Bat Scout"
+			Item	"The Concheror"
+			Attributes	"SpawnWithFullCharge"
+			Skill	Hard
+		}
+		ConchMinigiant
+		{
+			Template	T_TFBot_Soldier_Extended_Concheror
+			ClassIcon	soldier_armored_conch
+			Skill	Hard
+			Scale	1.4
+			Health	600
+		}
+		DHMinigiant
+		{
+			Class	Soldier
+			Name	"Direct Hit Soldier"
+			Item	"The Direct Hit"
+			ClassIcon	soldier_dh_lite_armored
+			Skill	Hard
+			Scale	1.4
+			Health	600
+		}
+		ShotgunMinigiant
+		{
+			Template	T_TFBot_Heavyweapons_Shotgun
+			WeaponRestrictions	SecondaryOnly
+			ClassIcon	heavy_shotgun_armored
+			Scale	1.4
+			Health	900
+		}
+		ILovePersia
+		{
+			Class Demoman
+			ClassIcon demoknight_persian_nys
+			Name "Very Persuasive"
+			Skill Hard
+			Item "Ali Baba's Wee Booties"
+			Item "The Splendid Screen"
+			Item "The Persian Persuader"
+			Item "Sultan's Ceremonial"
+			MaxVisionRange 800
+			WeaponRestrictions MeleeOnly
+			ItemAttributes
+			{
+				ItemName "The Splendid Screen"
+				"Attack not cancel charge" 1
+			}
+			ItemAttributes
+			{
+				ItemName "The Persian Persuader"
+				"critboost on kill" 3
+			}
+		}
+		GigaburstNoCrit
+		{
+			Class Soldier
+			Name "Giant Burst Fire Soldier"
+			Health 4200
+			Skill Expert
+			WeaponRestrictions PrimaryOnly
+			Attributes MiniBoss
+			Attributes HoldFireUntilFullReload
+			ItemAttributes
+			{
+				ItemName "TF_WEAPON_ROCKETLAUNCHER"
+				"damage bonus" 2.0
+				"faster reload rate" 0.4
+				"fire rate bonus" 0.2
+				"clip size upgrade atomic" 5.0
+			}
+			CharacterAttributes
+			{
+				"move speed bonus"	0.5
+				"damage force reduction" 0.4
+				"airblast vulnerability multiplier" 0.4
+				"override footstep sound set" 3
+				"Projectile speed increased" 0.9
+			}
+			ClassIcon	soldier_burstfire_hyper_lite
+		}
+		GiantDemoBurstTrapper
+		{
+			Template	T_TFBot_Giant_Demo_RapidFire
+			ClassIcon	demo_burst
+			Health	15000
+			Scale	1.8
+			Attributes	UseBossHealthBar
+			Attributes	MiniBoss
+			Attributes	HoldFireUntilFullReload
+			Attributes	AlwaysFireWeapon
+			Name	"Giant Roller Trap Demoman"
+//			Taunt    //Taunt periodically
+//			{
+//				Delay 1 //Time before the first taunt starts (Default: 10)
+//				Cooldown 9 //Time between each taunt (Default: 10)
+//				Repeats 0 //How many times the bot should taunt in total (Default: 0 - Infinite)
+//			}
+			CharacterAttributes
+			{
+				"no self blast dmg" 1
+				"gesture speed increase" 0.5
+				"mult projectile count" 4
+				"mult projectile scale" 2
+				"projectile spread angle penalty" 10
+				"clip size bonus" 0.25
+				"fire rate bonus" 0.0001
+				"Reload time increased" 2.55
+				"Projectile speed decreased" 0.5
+				"fuse bonus" 2
+				"Blast radius increased" 1.65
+				"damage bonus" 2.5
+				"mult dmg direct hit" 0.33
+				"no_jump" 1
+				"airblast vulnerability multiplier" 0.1
+				"damage force reduction" 0.1
+				"rage giving scale" 0.2
+			}
+		}
+		GiantHasteHeavyMiniboss
+		{
+			Template	T_TFBot_Giant_Heavyweapons
+			ClassIcon	heavy_hyper
+			Health	25000
+			Scale	1.8
+			Attributes	UseBossHealthBar
+			Attributes	MiniBoss
+			WeaponRestrictions	MeleeOnly
+			Name	"Private Mannpower"
+			ChangeAttributes    //Periodically changes bot attributes, defined in EventChangeAttributes
+			{
+				Delay 0 //Time before the first bot attribute change (Default: 10)
+				Repeats 1 //How many times should bot change attributes in total (Default: 0 - Infinite)
+				Name "FistHaste" // Name of the bot attributes listed in EventChangeAttributes
+			}
+			ChangeAttributes    //Periodically changes bot attributes, defined in EventChangeAttributes
+			{
+				Delay 0 //Time before the first bot attribute change (Default: 10)
+				Repeats 1 //How many times should bot change attributes in total (Default: 0 - Infinite)
+				IfHealthBelow 19000 //When set, the task activates only when the bot health is below specified value
+				Name "ShotgunHaste" // Name of the bot attributes listed in EventChangeAttributes
+			}
+			ChangeAttributes    //Periodically changes bot attributes, defined in EventChangeAttributes
+			{
+				Delay 0 //Time before the first bot attribute change (Default: 10)
+				Repeats 1 //How many times should bot change attributes in total (Default: 0 - Infinite)
+				IfHealthBelow 11000 //When set, the task activates only when the bot health is below specified value
+				Name "MinigunHaste" // Name of the bot attributes listed in EventChangeAttributes
+			}
+			EventChangeAttributes
+			{
+				FistHaste
+				{
+					Item	"The Killing Gloves of Boxing"
+					WeaponRestrictions	MeleeOnly
+					Addcond
+					{
+						Index 103
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "PlayVO"
+						Param  "items\powerup_pickup_knockout.wav"
+						Delay  3
+						Cooldown 9999
+					}
+					CharacterAttributes
+					{
+						"move speed bonus"	0.5
+						"rage giving scale" 0.2
+					}
+				}
+				ShotgunHaste
+				{
+					Item	"The Family Business"
+					WeaponRestrictions	SecondaryOnly
+					Attributes	HoldFireUntilFullReload
+					Addcond
+					{
+						Index 91
+					}
+					CharacterAttributes
+					{
+						"move speed bonus"	0.325
+						"rage giving scale" 0.2
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "PlayVO"
+						Param  "items\powerup_pickup_haste.wav"
+						Delay  0
+						Cooldown 9999
+					}
+				}
+				MinigunHaste
+				{
+					WeaponRestrictions	PrimaryOnly
+					Addcond
+					{
+						Index 94
+					}
+					FireInput
+					{
+						Target "tf_gamerules"
+						Action "PlayVO"
+						Param  "items\powerup_pickup_vampire.wav"
+						Delay  0
+						Cooldown 9999
+					}
+					FireInput
+					{
+						Target "!self"
+						Action "$RemoveCond"
+						Param  "91"
+						Delay  0
+						Cooldown 9999
+					}
+					CharacterAttributes
+					{
+						"move speed bonus"	0.25
+						"rage giving scale" 0.2
+					}
+				}
+			}
+		}
+		
+	}
+	Wave //WAVE 1 - CASH 700
+	{
+		WaitWhenDone	65
+		Checkpoint	Yes
+		InitWaveOutput
+		{
+			Target bombpath_2_relay
+			Action Trigger
+			Delay	1
+		}
+		StartWaveOutput
+		{
+			Target	wave_start_relay
+			Action	Trigger
+		}
+		DoneOutput
+		{
+			Target	wave_finished_relay
+			Action	Trigger
+		}
+		WaveSpawn
+		{
+			Name	Main1a
+			TotalCurrency	66
+			TotalCount	3
+			MaxActive	3
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	14
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Giant_Pyro
+				WeaponRestrictions	SecondaryOnly
+				Attributes HoldFireUntilFullReload
+				ClassIcon	heavy_shotgun
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllDead ""
+			Where spawnbot_aggr
+			Where spawnbot_right
+			Where spawnbot
+			TotalCount 40
+			MaxActive 40
+			SpawnCount 1
+			WaitBeforeStarting 3
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 50
+		
+			TFBot
+			{ 
+				Template T_TFBot_Scout_Melee
+				ClassIcon scout_bat_nys
+			}
+		}
+		WaveSpawn
+		{
+			Name	Main1c
+			TotalCurrency	50
+			TotalCount	21
+			MaxActive	9
+			SpawnCount	3
+			Where	spawnbot
+			Where	spawnbot
+			Where	spawnbot_right
+			WaitBeforeStarting	10
+			WaitBetweenSpawns	6
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Demoman
+				Skill	Hard
+			}
+		}
+        WaveSpawn
+		{
+			WaitForAllSpawned	Main2b
+			Name	Main3
+			TotalCurrency	75
+			TotalCount	3
+			MaxActive	3
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	20
+			WaitBetweenSpawns	14
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Giant_Soldier
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main3
+			Name	Main2
+			TotalCurrency	100
+			TotalCount	2
+			MaxActive	2
+			SpawnCount	2
+			Where	spawnbot
+			WaitBeforeStarting	20
+			WaitBetweenSpawns	18
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Giant_Boxing_Heavy
+				Tag giant
+				Item "Fists of Steel"
+				Name "Giant Steel Gauntlet"
+				ClassIcon heavy_steelfist
+			}
+		}
+//		WaveSpawn
+//		{
+//			WaitForAllSpawned	Main1b
+//			Name	Main2b
+//			TotalCurrency	100
+//			TotalCount	15
+//			MaxActive	9
+//			SpawnCount	1
+//			Where	spawnbot
+//			Where	spawnbot
+//			Where	spawnbot_right
+//			Where	spawnbot_aggr
+//			WaitBeforeStarting	20
+//			WaitBetweenSpawns	3
+//			RandomSpawn 1
+//			TFBot
+//			{
+//				Class	Heavyweapons
+//				Name	"Heavy"
+//				Skill	Easy
+//			}
+//		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main1a
+			Name	Main2ba
+			TotalCurrency	175
+			TotalCount	18
+			MaxActive	8
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	15
+			WaitBetweenSpawns	1
+			RandomSpawn 1
+			TFBot
+			{
+				Class	Soldier
+				WeaponRestrictions	PrimaryOnly
+			}
+		}
+		
+		WaveSpawn
+		{
+            WaitForAllSpawned	Main2
+			Name	Main3b
+			TotalCurrency	75
+			TotalCount	20
+			MaxActive	8
+			SpawnCount	2
+			Where	spawnbot
+			Where	spawnbot
+			Where	spawnbot_right
+			WaitBeforeStarting	10
+			WaitBetweenSpawns	4
+			RandomSpawn 1
+			Support 1
+			TFBot
+			{
+				Class	Scout
+				WeaponRestrictions	PrimaryOnly
+				Skill easy
+//				ClassIcon	scout_pistol_nys
+//				Name	"Pistol Scout"
+			}
+		}
+		WaveSpawn
+		{
+            WaitForAllSpawned	Main2
+			Name	Main3b
+			TotalCurrency	109
+			TotalCount	18
+			MaxActive	6
+			SpawnCount	3
+			Where	spawnbot
+			Where	spawnbot
+			Where	spawnbot_aggr
+			WaitBeforeStarting	10
+			WaitBetweenSpawns	10
+			RandomSpawn 1
+			Support 1
+			TFBot
+            {
+                Template T_TFBot_Demoman_Knight
+                ClassIcon	pyro_homewrecker_lite_armored
+                Name    "Chargin' Mace"
+                Item	"The Homewrecker"
+                Item    "The Tide Turner"
+                Health 300
+                Scale 1.3
+                CharacterAttributes
+				{
+					"dmg pierces resists absorbs"	1
+                    "charge time increased" 2
+				}
+            }
+		}
+	}
+	
+	Wave //WAVE 2 - CASH 700
+	{
+		WaitWhenDone	65
+		Checkpoint	Yes
+		InitWaveOutput
+		{
+			Target bombpath_1_relay
+			Action Trigger
+			Delay	1
+		}
+		StartWaveOutput
+		{
+			Target	wave_start_relay
+			Action	Trigger
+		}
+		DoneOutput
+		{
+			Target	wave_finished_relay
+			Action	Trigger
+		}
+		WaveSpawn
+		{
+			Name	Main1
+			TotalCurrency	100
+			TotalCount	1
+			MaxActive	1
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	30
+			RandomSpawn 1
+			TFBot
+			{
+				Template	GiantDemoBurstTrapper
+				Tag giant
+			}
+			FirstSpawnOutput
+			{
+				Target	TrainWarn
+				Action	Trigger
+			}
+		}
+//		WaveSpawn
+//		{
+//			Name	Main1b
+//			TotalCurrency	100
+//			TotalCount	6
+//			MaxActive	4
+//			SpawnCount	2
+//			Where	spawnbot
+//			WaitBeforeStarting	1
+//			WaitBetweenSpawns	8
+//			RandomSpawn 1
+//			TFBot
+//			{
+//				Template	T_TFBot_Sniper_Huntsman
+//			}
+//		}
+		WaveSpawn
+		{
+			Name	Main1b
+			TotalCurrency	100
+			TotalCount	20
+			MaxActive	8
+			SpawnCount	2
+			Where	spawnbot
+			WaitBeforeStarting	1
+			WaitBetweenSpawns	3
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Heavyweapons_Heavyweight_Champ
+				Name "Featherweight Champ"
+				Item	"The Holiday Punch"
+				ClassIcon heavy_mittens
+				Attributes	AlwaysCrit
+				Tag flank
+				Tag giant
+				CharacterAttributes
+				{
+					"cancel falling damage" 1
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name	Main1b
+			TotalCurrency	100
+			TotalCount	12
+			MaxActive	10
+			SpawnCount	6
+			Where	spawnbot_train
+			WaitBeforeStarting	8
+			WaitBetweenSpawns	8
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Heavyweapons_Heavyweight_Champ
+				Name "Featherweight Champ"
+				Item	"The Holiday Punch"
+				ClassIcon heavy_mittens
+				Attributes	AlwaysCrit
+				Tag flank
+				CharacterAttributes
+				{
+					"cancel falling damage" 1
+				}
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllDead	Main1
+			Name	Main2
+			TotalCurrency	200
+			TotalCount	1
+			MaxActive	1
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	8
+			RandomSpawn 1
+			Tank
+			{
+				Health	16000
+				StartingPathTrackNode boss_path_1
+				OnKilledOutput                                  
+				{
+					Target boss_dead_relay
+					Action Trigger                         
+				}
+				OnBombDroppedOutput                             
+				{
+					Target boss_deploy_relay 
+					Action Trigger                         
+				}
+			}
+			FirstSpawnOutput
+			{
+				Target	tank_hologram_left_enable_relay
+				Action	Trigger
+			}
+			DoneOutput
+			{
+				Target	tank_hologram_disable_relay
+				Action	Trigger
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllDead	Main1
+			WaitForAllSpawned	Main1b
+			Name	Main2b
+			TotalCurrency	100
+			TotalCount	30
+			MaxActive	12
+			SpawnCount	4
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	6
+			RandomSpawn 1
+			Support	limited
+			Squad
+			{
+                TFBot
+                {
+                    Template	T_TFBot_Heavyweapons_Heavyweight_Champ
+                }
+                TFBot
+                {
+                    Template	T_TFBot_Medic_BigHeal
+                    WeaponRestrictions	SecondaryOnly
+                }
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllDead	Main1
+			WaitForAllSpawned	Main1b
+			Name	Main2b
+			TotalCurrency	100
+			TotalCount	20
+			MaxActive	6
+			SpawnCount	2
+			Where	spawnbot
+			Where	spawnbot_right
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	6
+			RandomSpawn 1
+			Support	1
+			TFBot
+			{
+				Class	Scout
+				Name	"Scout"
+				WeaponRestrictions	PrimaryOnly
+				Skill	Easy
+				Tag flank
+			}
+		}
+        WaveSpawn
+		{
+			WaitForAllDead	Main1
+			WaitForAllSpawned	Main1b
+			Name	Main2b
+			TotalCurrency	0
+			TotalCount	20
+			MaxActive	8
+			SpawnCount	4
+			Where	spawnbot
+			Where	spawnbot_right
+			WaitBeforeStarting	15
+			WaitBetweenSpawns	8
+			RandomSpawn 1
+			Support	1
+			TFBot
+			{
+				Template T_TFBot_Pyro_Flaregun
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllDead	Main1
+			WaitForAllSpawned	Main1b
+			Name	Main3b
+			TotalCurrency	100
+			TotalCount	4
+			MaxActive	4
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	14
+			RandomSpawn 1
+			TFBot
+			{
+				Class Pyro
+				Tag giant
+				ClassIcon pyro_dragon_fury_swordstone
+				Name "Giant Furious Pyro"
+				Skill Expert
+				Health 3500
+				WeaponRestrictions PrimaryOnly
+				Attributes MiniBoss
+				MaxvisionRange 1000
+				Item	"neptune's nightmare"
+				Item "The Dragon's Fury"
+				ItemAttributes
+				{
+					ItemName "The Dragon's Fury"
+					"airblast disabled" 1
+				}
+				CharacterAttributes
+				{
+					"move speed bonus"	0.5
+					"damage force reduction" 0.6
+					"airblast vulnerability multiplier" 0.6
+					"override footstep sound set" 6
+				}	
+			}
+		}
+	}
+	Wave // Wave 3 - CASH 700
+	{
+		StartWaveOutput
+		{
+			Target wave_start_relay
+			Action Trigger
+		}
+		DoneOutput
+		{
+			Target wave_finished_relay
+			Action Trigger
+		}
+		InitWaveOutput
+		{
+			Target bombpath_1_relay
+			Action Trigger
+			Delay 1
+		}
+		WaveSpawn
+		{
+			Name "w3a"
+			WaitForAllDead ""
+			Where spawnbot
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 25
+		
+			TFBot
+			{ 
+				Template T_TFBot_Giant_Soldier_SlowBarrage 
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			Name "w3a"
+			WaitForAllDead ""
+			Where spawnbot_aggr
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 0.1
+			WaitBetweenSpawns 0.1
+		
+			TotalCurrency 25
+		
+			TFBot
+			{ 
+				Template T_TFBot_Giant_Soldier_Spammer_Reload
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			Name "w3a"
+			WaitForAllDead ""
+			Where spawnbot_right
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 0.1
+			WaitBetweenSpawns 0.1
+		
+			TotalCurrency 25
+		
+			TFBot
+			{ 
+				Template T_TFBot_Giant_Soldier_Spammer_Reload
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			Name "w3b"
+			WaitForAllDead ""
+			Where spawnbot_right
+			Where spawnbot
+			Where spawnbot_aggr
+			TotalCount 4
+			MaxActive 3
+			SpawnCount 1
+			WaitBeforeStarting 20
+			WaitBetweenSpawns 10
+		
+			TotalCurrency 75
+
+			TFBot
+			{
+				Health 3000
+				ClassIcon scout_armored_pda_giant
+				Name "Giant Armoured Scout"
+				Template	T_TFBot_Giant_Scout
+				Item "B-ankh!"
+				Skill Normal
+				Tag giant
+				CharacterAttributes
+				{
+					"override footstep sound set" 5
+					"move speed penalty" 0.65
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name "w3b"
+			WaitForAllDead "w3a"
+			Where spawnbot_aggr
+			Where spawnbot_right
+			TotalCount 40
+			MaxActive 20
+			SpawnCount 5
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 4.5
+		
+			TotalCurrency 75
+		
+			TFBot
+			{
+				Class Demoman
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	"w3b"
+			Name	"w3ba"
+			TotalCurrency	25
+			TotalCount	1
+			MaxActive	1
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	0
+			Tank
+			{
+				Health	19000
+				StartingPathTrackNode boss_path_2
+				OnKilledOutput                                  
+				{
+					Target boss_dead_relay
+					Action Trigger                         
+				}
+				OnBombDroppedOutput                             
+				{
+					Target boss_deploy_relay 
+					Action Trigger                         
+				}
+			}
+			FirstSpawnOutput
+			{
+				Target	tank_hologram_right_enable_relay
+				Action	Trigger
+			}
+			DoneOutput
+			{
+				Target	tank_hologram_disable_relay
+				Action	Trigger
+			}
+		}
+		WaveSpawn
+		{
+			Name "w3bb"
+			WaitForAllSpawned "w3ba"
+			Where spawnbot_right
+			TotalCount 2
+			MaxActive 2
+			SpawnCount 1
+			WaitBeforeStarting 20
+			WaitBetweenSpawns 20
+		
+			TotalCurrency 50
+		
+			TFBot
+			{ 
+				Template T_TFBot_Giant_Soldier_Spammer_Reload
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			Name "w3bb"
+			WaitForAllSpawned "w3ba"
+			Where spawnbot
+			TotalCount 50
+			MaxActive 16
+			SpawnCount 2
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 2
+		
+			TotalCurrency 150
+
+			RandomChoice
+			{
+				Shuffle 1
+				
+				TFBot
+				{
+					Template T_TFBot_Soldier_Extended_Buff_Banner
+				}
+				
+				TFBot
+				{
+					Class Demoman
+					Skill Expert
+					ClassIcon 	demo_loch_nys
+					Item	"the loch-n-load"
+					Item "Hazard Headgear"
+				}
+				TFBot
+				{
+					ClassIcon	soldier_directhit_lite
+					Health	200
+					Name	"Direct Hit Soldier"
+					Class	Soldier
+					Skill	Expert
+					Item	"the direct hit"
+				}
+				TFBot
+				{
+					Class Demoman
+					Skill Expert
+					ClassIcon 	demo_loch_nys
+					Item	"the loch-n-load"
+					Item "Hazard Headgear"
+				}
+				TFBot
+				{
+					ClassIcon	soldier_directhit_lite
+					Health	200
+					Name	"Direct Hit Soldier"
+					Class	Soldier
+					Skill	Expert
+					Item	"the direct hit"
+				}
+				TFBot
+				{
+					ClassIcon	soldier_directhit_lite
+					Health	200
+					Name	"Direct Hit Soldier"
+					Class	Soldier
+					Skill	Expert
+					Item	"the direct hit"
+				}
+				TFBot
+				{
+					Class Demoman
+					Skill Expert
+					ClassIcon 	demo_loch_nys
+					Item	"the loch-n-load"
+					Item "Hazard Headgear"
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllSpawned "boss"
+			Where spawnbot_aggr
+			Where spawnbot_right
+			TotalCount 99
+			MaxActive 10
+			SpawnCount 3
+			WaitBeforeStarting 10
+			WaitBetweenSpawns 9
+			Support 1
+			TotalCurrency 50
+		
+			TFBot
+			{ 
+				Template T_TFBot_Heavy_IronFist_Airblast
+				ClassIcon heavy_steelfist_pusher
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllSpawned "boss"
+			Where spawnbot
+			TotalCount 9
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 10
+			Support 1
+			TotalCurrency 50
+		
+			TFBot
+			{
+				Template T_TFBot_Giant_Scout
+				ClassIcon scout_bat_nys
+				Name "Giant Bat Scout"
+				WeaponRestrictions MeleeOnly
+				Tag giant
+        	}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned "w3bb"
+			Name "boss"
+			Where spawnbot
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 22
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 125
+			FirstSpawnWarningSound mvm/giant_heavy/giant_heavy_entrance.wav
+			LastSpawnWarningSound vo\mvm\norm\soldier_mvm_laughevil02.mp3
+			DoneWarningSound vo\mvm\norm\soldier_mvm_paincrticialdeath04.mp3
+			TFBot
+			{
+				ClassIcon 	soldier_gib_jumper_lite
+				Class	Soldier
+				Name	"barry"
+				Health 4000
+				Attributes UseBossHealthBar
+				Skill	Expert
+				MaxVisionRange	1300
+				Attributes Autojump
+				Attributes DisableDodge
+                ExtAttr IgnoreBuildings
+				Autojumpmax 1
+				Autojumpmin 1
+				Action Mobber
+				AlwaysGLow 1
+				WeaponSwitch
+					{
+						Type "Melee"
+						MaxTargetRange 200
+						MinTargetRange 1
+						Delay 0.1
+						Repeats 0
+						Cooldown 0
+						IfSeeTarget 1
+					}
+					WeaponSwitch
+					{
+						Type "Primary"
+						MaxTargetRange 9999
+						MinTargetRange 301
+						Delay 0.1
+						Repeats 0
+						Cooldown 0
+						IfSeeTarget 1
+					}
+				ItemAttributes
+				{
+					ItemName	"tf_weapon_rocketlauncher"
+					"override projectile type"	3
+					"fuse bonus" 0.295
+					"damage bonus" 1
+					"faster reload rate" 0.01
+					"fire rate bonus" 1.2
+					"clip size bonus" 5
+					"apply look velocity on damage" 1300
+					"apply z velocity on damage" 250
+					"Projectile speed increased HIDDEN" 2
+					"projectile no deflect" 1
+				}
+				ItemAttributes
+				{
+					Itemname "the market gardener"
+					"deploy time decreased" 0.01
+					"damage bonus" 1.5
+					"dmg bonus vs buildings" 5
+				}
+				ItemAttributes
+				{
+					Itemname "The Mantreads"
+					"increased air control" 4
+				}
+				CharacterAttributes
+				{
+					"attach particle effect" 3042
+					"blast dmg to self increased" 0.2
+					"cancel falling damage" 1
+					"melee range multiplier" 2.5
+					"increased jump height" 0.9
+					"damage force reduction" 0.1
+					//"dmg from ranged reduced" 0.85
+					"cannot be backstabbed" 1
+				}
+				Item	"the market gardener"
+				Item "The Mantreads"
+			}
+			FirstSpawnOutput
+			{
+				Target	TrainWarn
+				Action	Trigger
+				Delay 1
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned "w3bb"
+			Name "boss"
+			Where spawnbot_train
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 31
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 125
+			FirstSpawnWarningSound mvm/giant_heavy/giant_heavy_entrance.wav
+			LastSpawnWarningSound vo\mvm\norm\soldier_mvm_laughevil01.mp3
+			DoneWarningSound vo\mvm\norm\soldier_mvm_paincrticialdeath04.mp3
+			TFBot
+			{
+				ClassIcon 	soldier_gib_jumper_lite
+				Class	Soldier
+				Name	"harry"
+				Health 4000
+				Attributes UseBossHealthBar
+				Skill	Expert
+				MaxVisionRange	1300
+				Attributes Autojump
+				Attributes DisableDodge
+                ExtAttr IgnoreBuildings
+				Autojumpmax 1
+				Autojumpmin 1
+				Action Mobber
+				AlwaysGLow 1
+				WeaponSwitch
+					{
+						Type "Melee"
+						MaxTargetRange 200
+						MinTargetRange 1
+						Delay 0.1
+						Repeats 0
+						Cooldown 0
+						IfSeeTarget 1
+					}
+					WeaponSwitch
+					{
+						Type "Primary"
+						MaxTargetRange 9999
+						MinTargetRange 301
+						Delay 0.1
+						Repeats 0
+						Cooldown 0
+						IfSeeTarget 1
+					}
+				ItemAttributes
+				{
+					ItemName	"tf_weapon_rocketlauncher"
+					"override projectile type"	3
+					"fuse bonus" 0.295
+					"damage bonus" 1
+					"faster reload rate" 0.01
+					"fire rate bonus" 1.2
+					"clip size bonus" 5
+					"apply look velocity on damage" 1300
+					"apply z velocity on damage" 250
+					"Projectile speed increased HIDDEN" 2
+					"projectile no deflect" 1
+				}
+				ItemAttributes
+				{
+					Itemname "the market gardener"
+					"deploy time decreased" 0.01
+					"damage bonus" 1.5
+					"dmg bonus vs buildings" 5
+				}
+				ItemAttributes
+				{
+					Itemname "The Mantreads"
+					"increased air control" 4
+				}
+				CharacterAttributes
+				{
+					"attach particle effect" 3042
+					"blast dmg to self increased" 0.2
+					"cancel falling damage" 1
+					"melee range multiplier" 2.5
+					"increased jump height" 0.9
+					"damage force reduction" 0.1
+					// "dmg from ranged reduced" 0.85
+					"cannot be backstabbed" 1
+				}
+				Item	"the market gardener"
+				Item "The Mantreads"
+			}
+		}
+	}
+	Wave //WAVE 4 - CASH 700
+	{
+		WaitWhenDone	65
+		Checkpoint	Yes
+		InitWaveOutput
+		{
+			Target bombpath_2_relay
+			Action Trigger
+			Delay	1
+		}
+		StartWaveOutput
+		{
+			Target	wave_start_relay
+			Action	Trigger
+		}
+		DoneOutput
+		{
+			Target	wave_finished_relay
+			Action	Trigger
+		}
+		WaveSpawn
+		{
+			Name	Main1
+			TotalCurrency	100
+			TotalCount	1
+			MaxActive	1
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	0
+			RandomSpawn 1
+			FirstSpawnWarningSound mvm/giant_heavy/giant_heavy_entrance.wav
+			TFBot
+			{
+				Template	GiantHasteHeavyMiniboss
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			Name	Main1b
+			TotalCurrency	100
+			TotalCount	40
+			MaxActive	20
+			SpawnCount	5
+			Where	spawnbot
+			Where	spawnbot_right
+			WaitBeforeStarting	2
+			WaitBetweenSpawns	0
+			TFBot
+            { 
+                Template T_TFBot_Heavyweapons_Heavyweight_Champ
+                Item     "The Concheror"
+                Attributes      SpawnWithFullCharge
+                ClassIcon heavy_champ_conch2
+                Name "Extended Conch Punchie"
+                Attributes AlwaysCrit
+                CharacterAttributes
+                {
+                    "increase buff duration"	141.0
+                }
+            }
+		}
+		WaveSpawn
+		{
+			WaitForAllDead	Main1
+			Name	Main2
+			TotalCurrency	100
+			TotalCount	4
+			MaxActive	4
+			SpawnCount	1
+			Where	spawnbot
+			Where 	spawnbot_aggr
+			Where 	spawnbot_right
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	13
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Giant_Scout_Baseball_Armored
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main1b
+			Name	Main2b
+			TotalCurrency	50
+			TotalCount	20
+			MaxActive	10
+			SpawnCount	4
+			Where	spawnbot
+			WaitBeforeStarting	8
+			WaitBetweenSpawns	6
+			RandomSpawn 1
+			TFBot
+			{
+				Class	Heavyweapons
+				Skill	Easy
+				Name	"Heavy"
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main2b
+			Name	Main2ba
+			TotalCurrency	50
+			TotalCount	12
+			MaxActive	6
+			SpawnCount	2
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	7
+			RandomSpawn 1
+			Squad
+			{
+				TFBot
+                {
+                    Class Soldier
+                    Skill Hard
+                    ClassIcon soldier_burstfire_armored_yoovy
+                    Health 900
+                    Name "Armored Burst Fire Soldier"
+                    Scale 1.4
+                    Attributes HoldFireUntilFullReload
+                    NoBombUpgrades 1
+                    ItemAttributes
+                    {
+                        ItemName "TF_WEAPON_ROCKETLAUNCHER"
+                        "faster reload rate" 0.7
+                        "fire rate bonus" 0.2
+                        "clip size upgrade atomic" 2.0
+						"projectile speed increased" 0.6
+                    }
+                    CharacterAttributes
+                    {
+                        "head scale" 0.7
+                    } 
+                }
+				TFBot
+				{
+					Template	T_TFBot_Medic_BigHeal
+				}
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main2
+			Name	Main3
+			TotalCurrency	200
+			TotalCount	3
+			MaxActive	3
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	15
+			RandomSpawn 1
+			TFBot
+			{
+				Template	T_TFBot_Giant_Heavyweapons
+				Tag giant
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main2
+			Name	Main3b
+			TotalCurrency	100
+			TotalCount	30
+			MaxActive	10
+			SpawnCount	2
+			Where	spawnbot
+			WaitBeforeStarting	20
+			WaitBetweenSpawns	4
+			RandomSpawn 1
+			Support	1
+			TFBot
+            {
+                Name "Beggar's Soldier"
+                Class Soldier
+                Skill Hard
+                Item "The Beggar's Bazooka"
+                ClassIcon 	soldier_bazooka
+				Tag flank
+                ItemAttributes
+                {
+                    ItemName "The Beggar's Bazooka"
+                    "can overload" 0
+                    "auto fires full clip" 1
+                    "reload time increased hidden" 1
+                    "faster reload rate" 0.6
+                }
+            }
+		}
+	}
+	Wave //WAVE 5 - CASH 700
+	{
+		WaitWhenDone	65
+		Checkpoint	Yes
+		InitWaveOutput
+		{
+			Target bombpath_2_relay
+			Action Trigger
+			Delay	1
+		}
+		StartWaveOutput
+		{
+			Target	wave_start_relay
+			Action	Trigger
+		}
+		DoneOutput
+		{
+			Target	wave_finished_relay
+			Action	Trigger
+		}
+		WaveSpawn
+		{
+			Name	Main1a
+			TotalCurrency	100
+			TotalCount	2
+			MaxActive	2
+			SpawnCount	1
+			Where	spawnbot
+			WaitBeforeStarting	10
+			WaitBetweenSpawns	26
+			RandomSpawn 1
+			Tank
+			{
+				Health	25000
+				StartingPathTrackNode boss_path_2
+				OnKilledOutput                                  
+				{
+					Target boss_dead_relay
+					Action Trigger                         
+				}
+				OnBombDroppedOutput                             
+				{
+					Target boss_deploy_relay 
+					Action Trigger                         
+				}
+				
+			}
+			FirstSpawnOutput
+			{
+				Target	tank_hologram_right_enable_relay
+				Action	Trigger
+			}
+			DoneOutput
+			{
+				Target	tank_hologram_disable_relay
+				Action	Trigger
+			}
+		}
+		WaveSpawn
+		{
+			Name	Main1
+			TotalCurrency	20
+			TotalCount	15
+			MaxActive	15
+			SpawnCount	5
+			Where	spawnbot
+			Where	spawnbot
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	18
+			RandomSpawn 1
+			Squad
+			{
+				TFBot
+				{
+					Template	T_TFBot_Giant_Soldier_SlowBarrage
+					Tag giant
+				}
+				TFBot
+				{
+					Template T_TFBot_Medic
+				}
+				TFBot
+				{
+					Template T_TFBot_Medic
+				}
+				TFBot
+				{
+					Template T_TFBot_Medic
+				}
+				TFBot
+				{
+					Template T_TFBot_Medic
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name	Main1b
+			TotalCurrency	100
+			TotalCount	40
+			MaxActive	13
+			SpawnCount	5
+			Where	spawnbot
+			Where	spawnbot
+			Where	spawnbot_right
+			WaitBeforeStarting	0.1
+			WaitBetweenSpawns	7
+			RandomSpawn 1
+			TFBot
+			{
+				Template T_TFBot_Heavyweapons_Shotgun
+			}
+			
+		}
+		WaveSpawn
+		{
+			WaitForAllDead	Main1
+			Name	Main2
+			TotalCurrency	100
+			TotalCount	6
+			MaxActive	6
+			SpawnCount	2
+			Where	spawnbot_aggr
+			WaitBeforeStarting	0
+			WaitBetweenSpawns	15
+			RandomSpawn 1
+			Squad
+			{
+				NoFormation 1
+				TFBot
+				{
+					Template T_TFBot_Giant_Heavyweapons_Shotgun
+					ClassIcon heavy_shotgun_giant
+				}
+				TFBot
+				{
+					Template T_TFBot_Giant_Demoman
+					ClassIcon demo_spammer_giant
+				}
+			}
+			
+		}
+		WaveSpawn
+		{
+			WaitForAllDead	Main1
+			Name	Main2b
+			TotalCurrency	100
+			TotalCount	32
+			MaxActive	12
+			SpawnCount	4
+			Where	spawnbot
+			Where	spawnbot
+			Where	spawnbot_aggr
+			Where	spawnbot_right
+			WaitBeforeStarting	10
+			WaitBetweenSpawns	6
+			RandomSpawn 1
+			RandomChoice
+			{
+				TFBot
+				{
+					Template	T_TFBot_Sniper_Huntsman
+					Attributes AlwaysCrit
+				}
+				TFBot
+				{
+					Template T_TFBot_Demo_Burst
+					Attributes HoldFireUntilFullReload
+					Attributes AlwaysFireWeapon
+					ItemAttributes
+                    {
+                        ItemName tf_weapon_grenadelauncher
+                        "clip size upgrade atomic" 2						
+                    }
+				}
+				Shuffle 1
+			}
+		}
+		
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main2
+			Name	Main3
+			TotalCurrency	90
+			TotalCount	2
+			MaxActive	2
+			SpawnCount	2
+			Where	spawnbot
+			WaitBeforeStarting	15
+			WaitBetweenSpawns	15
+			RandomSpawn 1
+			Squad
+			{
+				TFBot
+				{
+					Template T_TFBot_Giant_Heavyweapons_HealOnKill
+					Item "Deflector"
+					Item "The Tungsten Toque"
+					Attributes UseBossHealthBar
+					Name "Giant Heal-On-Kill Deflector"
+					CharacterAttributes
+					{
+						"move speed bonus"	0.5
+						"damage force reduction" 0.3
+						"airblast vulnerability multiplier" 0.3
+						"override footstep sound set" 2
+					}
+				}
+				TFBot
+                {
+                    Class Medic
+                    Name "Armored BigHeal Shield Medic"
+                    Skill Expert
+                    ClassIcon 	medic_quickfix_armored_shield
+                    WeaponRestrictions SecondaryOnly
+                    Attributes SpawnWithFullCharge
+                    Attributes ProjectileShield
+                    Attributes IgnoreEnemies
+                    Health 650
+                    Scale 1.5
+                    Item "titanium tyrolean"
+                    FireWeapon
+                    {
+                        Delay 4 //Time before the first fire input starts (Default: 10)
+                        Cooldown 3 //Time between each fire input (Default: 10)
+                        Repeats 0 //How many times should bot use the fire input in total (Default: 0 - Infinite)
+                        //IfSeeTarget 1 //When set to 1, this task activates only when the bot can see the target player (Default 0 - Always activate)
+                        Duration 0.5 //How long should the button be pressed (Default: 0.1)
+                        Type "Special"
+                    }
+                    ItemAttributes
+                    {
+                        ItemName tf_weapon_medigun
+                        "ubercharge rate penalty" -3
+                        "generate rage on heal" 2
+                        "increase buff duration" 999
+						"heal rate bonus" 10
+                    }
+                    CharacterAttributes
+                    {
+                        "bot medic uber health threshold" 999
+                        "bot medic uber deploy delay duration" 9999
+                        "mod soldier buff type" 5
+                        "deploy time increased" 1.34
+                    }
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllSpawned "Main3"
+			Where spawnbot_aggr
+			Where spawnbot_right
+			TotalCount 2
+			MaxActive 2
+			SpawnCount 1
+			WaitBeforeStarting 10
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 90
+		
+			TFBot
+			{
+				Class Demoman
+				Name "Major Barrage"
+				Skill Expert
+				ClassIcon 		demo_scatter_giant
+				Health 4000
+				Attributes HoldFireUntilFullReload
+				Attributes MiniBoss
+				WeaponRestrictions PrimaryOnly
+				Item "Scotch Bonnet"
+				ItemAttributes
+				{
+					ItemName "TF_WEAPON_GRENADELAUNCHER"
+					"clip size upgrade atomic" 41.0
+					"damage bonus" 0.7
+					"fire rate bonus" 0.15
+					"Projectile speed increased" 0.88
+					"projectile spread angle penalty" 2.33
+					"faster reload rate" 0.09
+					"heal on hit for rapidfire" 3
+					"fuse bonus" 0.85
+				}
+				
+				CharacterAttributes
+				{
+					"move speed bonus"	0.5
+					"damage force reduction" 0.5
+					"airblast vulnerability multiplier" 0.5
+					"override footstep sound set" 4
+				}
+
+			}
+		}
+		WaveSpawn
+		{
+			WaitForAllSpawned	Main2b
+			Name	Main3b
+			TotalCurrency	100
+			TotalCount	30
+			MaxActive	18
+			SpawnCount	4
+			Where	spawnbot
+			Where	spawnbot
+			Where	spawnbot_right
+			WaitBeforeStarting	5
+			WaitBetweenSpawns	4
+			RandomSpawn 1
+			Support 1
+			RandomChoice
+			{
+				NextSpawnerClone 4
+				TFBot
+				{
+					Template	T_TFBot_Pyro
+					Skill	Easy
+				}
+				TFBot
+				{
+					Template	T_TFBot_Pyro
+					Skill	Easy
+					Tag flank
+				}
+				Shuffle 1
+			}
+		}
+	}
+	Wave // Wave #
+	{
+		StartWaveOutput
+		{
+			Target wave_start_relay
+			Action Trigger
+		}
+		DoneOutput
+		{
+			Target wave_finished_relay
+			Action Trigger
+		}
+		InitWaveOutput
+		{
+			Target bombpath_2_relay
+			Action Trigger
+			Delay 1
+		}
+		Explanation
+		{
+			Line "{yellow}There seems to be something going on with the holograms..."
+		}
+		WaveSpawn
+		{
+			Name "w6a"
+			WaitForAllDead ""
+			Where spawnbot
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 25
+		
+			TFBot
+			{
+				Template T_TFBot_Giant_Scout_Fast
+			}
+		}
+		WaveSpawn
+		{
+			Name "w6a"
+			WaitForAllDead ""
+			Where spawnbot_right
+			Where spawnbot
+			Where spawnbot_aggr
+			TotalCount 20
+			MaxActive 15
+			SpawnCount 5
+			WaitBeforeStarting 8
+			WaitBetweenSpawns 9
+		
+			TotalCurrency 50
+			Squad
+			{
+				TFBot
+				{
+					Health	3800
+					Name	"Giant Widowmaker Engineer"
+					Scale	1.7
+					ClassIcon 	engineer_widowmaker_nys_giant
+					Class	Engineer
+					Skill	Expert
+					WeaponRestrictions	PrimaryOnly
+					MaxVisionRange 900
+					Attributes	"MiniBoss"
+					Action FetchFlag
+					Item	"the widowmaker"
+					CharacterAttributes
+					{
+						"move speed bonus"	0.5
+						"damage force reduction"	0.5
+						"airblast vulnerability multiplier"	0.5
+						"override footstep sound set"	4
+						"voice pitch scale"	0
+					}
+				}
+				TFBot
+				{
+					Template T_TFBot_Soldier_Extended_Concheror
+				}
+				TFBot
+				{
+					Template T_TFBot_Soldier_Extended_Concheror
+				}
+				TFBot
+				{
+					Template T_TFBot_Soldier_Extended_Concheror
+				}
+				TFBot
+				{
+					Template T_TFBot_Soldier_Extended_Concheror
+				}
+			}
+			DoneOutput
+			{
+				Target "incomingpathswitch_left"
+				Action Trigger
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllDead ""
+			Where spawnbot
+			Where spawnbot_right
+			TotalCount 35
+			MaxActive 15
+			SpawnCount 5
+			WaitBeforeStarting 4.1
+			WaitBetweenSpawns 6.5
+		
+			TotalCurrency 50
+			RandomChoice
+			{
+				NextSpawnerClone 45
+				TFBot
+				{
+					Template T_TFBot_Demoman_Knight
+					ClassIcon	pyro_homewrecker_lite_armored
+					Name    "Jumping n' Chargin' Mace"
+					Item	"The Homewrecker"
+					Item    "The Chargin' Targe"
+					Health 450
+					Scale 1.3
+					Attributes AirChargeOnly
+					Attributes AutoJump
+					AutoJumpMin 7
+					AutoJumpMax 7
+					ItemAttributes
+					{
+						ItemName "The Chargin' Targe"
+						"Attack not cancel charge" 1
+					}
+					CharacterAttributes
+					{
+						"dmg pierces resists absorbs"	1
+						"charge time increased" 2
+						"charge recharge rate increased" 7
+						"increased jump height" 2.3
+						"bot custom jump particle"	1
+					}
+				}
+				
+				TFBot
+				{
+					Template T_TFBot_Demoman_Knight
+					ClassIcon	pyro_homewrecker_lite_armored
+					Name    "Kill People with Hammers"
+					Item	"The Homewrecker"
+					Item    "The Chargin' Targe"
+					Health 450
+					Scale 1.3
+					Attributes AirChargeOnly
+					Attributes AutoJump
+					AutoJumpMin 7
+					AutoJumpMax 7
+					ItemAttributes
+					{
+						ItemName "The Chargin' Targe"
+						"Attack not cancel charge" 1
+					}
+					CharacterAttributes
+					{
+						"dmg pierces resists absorbs"	1
+						"charge time increased" 2
+						"charge recharge rate increased" 7
+						"increased jump height" 2.3
+						"bot custom jump particle"	1
+						
+					}
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name "w6b"
+			WaitForAllDead "w6a"
+			Where spawnbot
+			TotalCount 4
+			MaxActive 4
+			SpawnCount 4
+			WaitBeforeStarting 5.5
+			WaitBetweenSpawns 0
+			FirstSpawnWarningSound "music/hl1_song17.mp3"
+			TotalCurrency 50
+		
+			TFBot
+			{ 
+				Template T_TFBot_Giant_Scout_Fast
+			}
+		}
+		WaveSpawn
+		{
+			Name "w6b"
+			WaitForAllDead "w6a"
+			Where spawnbot
+			TotalCount 4
+			MaxActive 4
+			SpawnCount 2
+			WaitBeforeStarting 6
+			WaitBetweenSpawns 30
+			TotalCurrency 50
+			Squad
+			{
+				TFBot // Thank you so much Yoovy, this template is sick
+				{
+					Class Soldier
+					Health 4200
+					Name "Giant Rocket Spreader"
+					ClassIcon soldier_rocketrain_giant
+					Attributes HoldFireUntilFullReload
+					Attributes MiniBoss
+					Tag bot_giant
+					CharacterAttributes
+					{
+						"airblast vertical vulnerability multiplier" 0.1
+						"airblast vulnerability multiplier" 0.1
+						"override footstep sound set" 5
+						"damage force reduction" 0.1
+						"move speed penalty" 0.5
+						"killstreak tier" 1
+					}
+
+					//Weapons
+					Item "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
+					ItemAttributes
+					{
+						ItemName "Upgradeable TF_WEAPON_ROCKETLAUNCHER"
+						"spread angle pattern" "0 0 0|0 10 0|0 20 0|0 30 0|0 40 0|0 50 0|0 40 0|0 30 0|0 20 0|0 10 0|0 0 0|0 -10 0|0 -20 0|0 -30 0|0 -40 0|0 -50 0|0 -40 0|0 -30 0|0 -20 0|0 -10 0|0 0 0"
+						"projectile speed decreased" 0.5
+						"paintkit_proto_def_index" 431 //Blackout
+						"clip size upgrade atomic" 26
+						"set_item_texture_wear" 0
+						"faster reload rate" 0.15
+						"fire rate bonus" 0.05f
+					}
+
+					//Cosmetics
+					Item "The Team Captain"
+					Item "Fancy Dress Uniform"
+				}
+				TFBot
+				{
+					Template T_TFBot_Giant_Medic_Regen
+				}
+			}
+		}
+		WaveSpawn // Tank # HP
+		{
+			Name "w6b"
+			WaitForAllDead "w6a"
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 10
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 50
+		
+			Tank
+			{
+				Name "tankboss"
+				StartingPathTrackNode "boss_path_1"
+				Health 20000
+				Speed 75
+				Skin 0
+		
+				OnKilledOutput {}
+				OnBombDroppedOutput
+				{
+					Target boss_deploy_relay
+					Action Trigger
+				}
+			}
+			FirstSpawnOutput
+			{
+				Target	tank_hologram_left_enable_relay
+				Action	Trigger
+			}
+			DoneOutput
+			{
+				Target	tank_hologram_disable_relay
+				Action	Trigger
+			}
+		}
+		WaveSpawn // Dummy
+		{
+			WaitForAllDead "w6b"
+			FirstSpawnOutput
+			{
+				Target "incomingpathswitch_right"
+				Action Trigger
+			}
+		}
+		WaveSpawn
+		{
+			Name "w6bsupp"
+			WaitForAllDead "w6a"
+			Where spawnbot_aggr
+            Where spawnbot_right
+			TotalCount 40
+			MaxActive 16
+			SpawnCount 6
+			WaitBeforeStarting 10
+			WaitBetweenSpawns 7
+		
+			TotalCurrency 50
+		
+			TFBot
+			{ 
+				Class Scout
+				Skill Hard
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllDead "w6a"
+			Where spawnbot_right
+			TotalCount 12
+			MaxActive 12
+			SpawnCount 3
+			WaitBeforeStarting 10
+			WaitBetweenSpawns 18
+		
+			TotalCurrency 50
+			Squad
+			{ 
+				TFBot
+				{ 
+					Template T_TFBot_Sniper_Huntsman_Spammer
+					ClassIcon sniper_bow_multi
+				}
+				TFBot
+				{
+					Class Pyro
+					Skill Expert
+					Attributes AlwaysFireWeapon
+				}
+				TFBot
+				{
+					Class Pyro
+					Skill Expert
+					Attributes AlwaysFireWeapon
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name "w6cs"
+			WaitForAllDead "w6b"
+			Where spawnbot
+			Where spawnbot_aggr
+			Where spawnbot_right
+			TotalCount 10
+			MaxActive 6
+			SpawnCount 1
+			WaitBeforeStarting 7
+			WaitBetweenSpawns 2.5
+		
+			TotalCurrency 25
+		
+			TFBot
+			{ 
+				Template T_TFBot_Giant_Scout_Fast
+			}
+		}
+		WaveSpawn
+        {
+            Name ""
+            WaitForAllDead "w6cs"
+            Where spawnbot
+            TotalCount 8
+            MaxActive 8
+            SpawnCount 1
+            WaitBeforeStarting 0
+            WaitBetweenSpawns 1.5
+            Support Limited
+            TotalCurrency 50
+        
+            TFBot
+            { Template T_TFBot_Engineer_Sentry_Teleporter ClassIcon engineer_battle TeleportWhere spawnbot_aggr TeleportWhere spawnbot_right }
+        }
+		WaveSpawn // Tank # HP
+		{
+			Name ""
+			WaitForAllDead "w6b"
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 10
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 25
+		
+			Tank
+			{
+				Name "tankboss"
+				StartingPathTrackNode "boss_path_2"
+				Health 30000
+				Speed 75
+				Skin 0
+		
+				OnKilledOutput {}
+				OnBombDroppedOutput
+				{
+					Target boss_deploy_relay
+					Action Trigger
+				}
+			}
+			FirstSpawnOutput
+			{
+				Target	tank_hologram_left_enable_relay
+				Action	Trigger
+			}
+		}
+		WaveSpawn // Tank # HP
+		{
+			Name ""
+			WaitForAllDead "w6b"
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			WaitBeforeStarting 20
+			WaitBetweenSpawns 0
+		
+			TotalCurrency 25
+		
+			Tank
+			{
+				Name "tankboss"
+				StartingPathTrackNode "boss_path_1"
+				Health 20000
+				Speed 75
+				Skin 1
+		
+				OnKilledOutput {}
+				OnBombDroppedOutput
+				{
+					Target boss_deploy_relay
+					Action Trigger
+				}
+			}
+			FirstSpawnOutput
+			{
+				Target	tank_hologram_right_enable_relay
+				Action	Trigger
+			}
+			DoneOutput
+			{
+				Target	tank_hologram_disable_relay
+				Action	Trigger
+			}
+		}
+		WaveSpawn
+		{
+			Name "w6ca"
+			WaitForAllDead "w6b"
+			Where spawnbot
+			TotalCount 4
+			MaxActive 4
+			SpawnCount 1
+			WaitBeforeStarting 8
+			WaitBetweenSpawns 10
+		
+			TotalCurrency 50
+		
+			TFBot
+			{ 
+				Class Demoman
+				Name "Giant Burst Fire Sticky Demo"
+				ClassIcon 	demo_sticky_burst_giant
+				Skill Expert
+				Health 3800
+				Item "Bomb Beanie"
+				Attributes HoldFireUntilFullReload
+				Attributes MiniBoss
+				WeaponRestrictions SecondaryOnly
+				ItemAttributes
+				{
+					ItemName "Bomb Beanie"
+					"set item tint rgb" 6535423
+				}
+				ItemAttributes
+				{
+					ItemName "TF_WEAPON_GRENADELAUNCHER"
+					"is_passive_weapon" 1
+					"override projectile type" 27
+					//"clip size bonus" 2
+				}
+				ItemAttributes
+				{
+					ItemName "TF_WEAPON_PIPEBOMBLAUNCHER"
+					"stickybomb charge rate" 0.0001
+					"faster reload rate" 0.4
+					"fire rate bonus" 0.01
+					"Projectile range increased" 0.4
+					"projectile spread angle penalty" 5
+				}
+				CharacterAttributes
+				{
+					"move speed bonus"    0.5
+					"damage force reduction" 0.5
+					"airblast vulnerability multiplier" 0.5
+					"override footstep sound set" 4
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name "w6csupp"
+			WaitForAllDead "w6b"
+			Where spawnbot_right
+			TotalCount 18
+			MaxActive 12
+			SpawnCount 3
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 5
+		
+			TotalCurrency 50
+			Squad
+			{
+				TFBot
+				{ 
+					Template T_TFBot_Sniper_Huntsman_Spammer
+					ClassIcon sniper_bow_multi
+				}
+				TFBot
+				{
+					Class Pyro
+					Skill Expert
+					Attributes AlwaysFireWeapon
+				}
+				TFBot
+				{
+					Class Pyro
+					Skill Expert
+					Attributes AlwaysFireWeapon
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllDead "w6csupp"
+			Where spawnbot_aggr
+			TotalCount 30
+			MaxActive 15
+			SpawnCount 5
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 7
+			Support limited
+			TotalCurrency 50
+			TFBot
+			{
+				ClassIcon	soldier_bison
+				Health	200
+				Name	"Bison Soldier"
+				Class	Soldier
+				Skill	Expert
+				Item	"the righteous bison"
+				WeaponRestrictions "SecondaryOnly"
+			}
+		}
+		WaveSpawn
+		{
+			Name ""
+			WaitForAllDead "w6ca"
+			Where spawnbot_aggr
+			TotalCount 30
+			MaxActive 15
+			SpawnCount 5
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 7
+			Support limited
+			TotalCurrency 50
+			TFBot
+			{
+				ClassIcon pyro_dragon_fury_swordstone
+				Name "Dragon's Fury Pyro"
+				Class Pyro
+				Skill Easy
+				Item "The Dragon's Fury"
+				MaxVisionRange 700
+				CharacterAttributes
+				{
+					"airblast disabled" 1
+				}
+			}
+		}
+	}
+	Wave //WAVE 6 - CASH 700
+	{
+		WaitWhenDone	65
+		Checkpoint	Yes
+		InitWaveOutput
+		{
+			Target wave_start_relay
+			Action RunScriptCode
+			Param "
+			EntFire(`bosswavelogic`,`forcespawn`)
+			EntFire(`bombpath_1_relay`,`trigger`)
+			"
+			Delay	0.5
+		}
+		StartWaveOutput
+		{
+			Target	wave_start_relay
+			Action	Trigger
+		}
+		DoneOutput
+		{
+			Target	wave_finished_relay
+			Action	Trigger
+		}
+		WaveSpawn // Dummy
+		{
+			WaitBeforeStarting 0
+			FirstSpawnOutput
+			{
+				Target "StartTheFight"
+				Action "Trigger"
+			}
+		}
+		WaveSpawn
+		{
+            Support 1
+		    Squad
+		    {
+		        TFBot
+		        {
+		            ClassIcon soldier_homing_direct_burst_giant
+		        }
+		        TFBot
+		        {
+		            ClassIcon pyro_neon_giant
+		        }
+				TFBot
+		        {
+		            ClassIcon soldier_airstrike
+		        }
+				TFBot
+		        {
+		            ClassIcon trash_meme
+		        }
+				TFBot
+		        {
+		            ClassIcon soldier_conch_burstfire_yoovy
+		        }
+				TFBot
+		        {
+		            ClassIcon soldier_rocketrain_giant
+		        }
+				TFBot
+		        {
+		            ClassIcon heavy_shotgun_burst_lite
+		        }
+				TFBot
+		        {
+		            ClassIcon soldier_nuke2
+		        }
+		    }
+		}
+		WaveSpawn
+		{
+			Name	Main1
+			TotalCurrency	100
+			TotalCount	1
+			MaxActive	1
+			SpawnCount	1
+			Where	spawnbot
+			Where	spawnbot
+			WaitBeforeStarting	6
+			WaitBetweenSpawns	5
+			RandomSpawn 1
+			TFBot
+			{
+				Template	BigFunnyBossMan
+				// Tag giant
+				Tag boss_bot
+                Action Mobber
+			}
+			DoneOutput
+			{
+				Target "bignet"
+				Action "RunScriptCode"
+				Param "TextualTimer.Pause()"
+			}
+		}
+		WaveSpawn
+        {
+            WaitForAllDead "Main1"
+            WaitBeforeStarting 0
+            FirstSpawnOutput
+            {
+                Target "pop_interface"
+                Action $KillWavespawn
+				Param "disablefor_ubergenerator"
+                Delay 0
+            }
+        }
+		WaveSpawn
+        {
+            WaitForAllDead "Main1"
+            WaitBeforeStarting 0
+            FirstSpawnOutput
+            {
+                Target "pop_interface"
+                Action $KillWavespawn
+				Param "disableformidboss"
+                Delay 0
+            }
+        }
+		WaveSpawn
+        {
+            WaitForAllDead "Main1"
+            WaitBeforeStarting 0
+            FirstSpawnOutput
+            {
+                Target "pop_interface"
+                Action $KillWavespawn
+				Param "forthesplashattack"
+                Delay 0
+            }
+        }
+		 WaveSpawn
+        {
+            WaitForAllDead "Main1"
+            WaitBeforeStarting 11
+            FirstSpawnOutput
+            {
+                Target "pop_interface"
+                Action $FinishWave
+                Delay 0
+            }
+        }
+		WaveSpawn
+		{
+			Name "disableformidboss"
+			WaitForAllDead ""
+			Where spawnbot_train
+			TotalCount 10
+			MaxActive 10
+			SpawnCount 1
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 0
+			Support 1
+			TotalCurrency 50
+			RandomChoice
+			{
+				TFBot
+				{ 
+					Template T_TFBot_Soldier_Extended_Concheror
+					Action Mobber
+				}
+				TFBot
+				{
+					Template T_TFBot_Demoman_Knight
+					ClassIcon	pyro_homewrecker_lite_armored
+					Name    "Chargin' Mace"
+					Item	"The Homewrecker"
+					Item    "The Tide Turner"
+					Health 300
+					Scale 1.3
+					Action Mobber
+					CharacterAttributes
+					{
+						"dmg pierces resists absorbs"	1
+						"charge time increased" 2
+					}
+				}
+			}
+			
+		}
+		WaveSpawn
+		{
+			Name "forthesplashattack"
+			WaitForAllDead ""
+			Where spawnbot_train
+			TotalCount 30
+			MaxActive 12
+			SpawnCount 4
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 0
+			Support 1
+			TotalCurrency 50
+		
+			TFBot
+			{ 
+				Class Pyro
+				Name "Armored Neon Annihilator"
+				WeaponRestrictions MeleeOnly
+				Health 300
+				Scale 1.3
+				Item "The Neon Annihilator"
+				ClassIcon pyro_neon
+				Action Mobber
+			}
+		}
+		WaveSpawn
+		{
+			Name "disablefor_ubergenerator"
+			WaitForAllDead ""
+			Where spawnbot_aggr
+			TotalCount 50
+			MaxActive 22
+			SpawnCount 1
+			WaitBeforeStarting 0
+			WaitBetweenSpawns 1.4
+			Support 1
+			TotalCurrency 400
+			RandomChoice
+			{
+				Shuffle 1
+				TFBot
+				{ 
+					Template T_TFBot_Sniper_Huntsman
+					Action Mobber
+				}
+				TFBot
+				{ 
+					Class Soldier
+					Action Mobber
+				}
+				TFBot
+				{ 
+					Template T_TFBot_Sniper_Huntsman
+					Action Mobber
+				}
+				TFBot
+				{ 
+					Class Soldier
+					Action Mobber
+				}
+				TFBot
+				{ 
+					Template T_TFBot_Heavy_IronFist_Airblast
+					Action Mobber
+				}
+				TFBot
+				{ 
+					Template T_TFBot_Scout_Shortstop
+					Action Mobber
+				}
+			}
+			
+		}
+		// WaveSpawn
+		// {
+		// 	Name	Main1
+		// 	TotalCurrency	100
+		// 	TotalCount	6
+		// 	MaxActive	2
+		// 	SpawnCount	2
+		// 	Where	spawnbot_aggr
+		// 	WaitBeforeStarting	25
+		// 	WaitBetweenSpawns	0
+		// 	RandomSpawn 1
+		// 	Support	1
+		// 	TFBot
+		// 	{
+		// 		Template	T_TFBot_Giant_Scout_Fast
+		// 		Health	1800
+		// 		Tag	bossbackup
+		// 		Tag giant
+		// 		Attributes	AlwaysCrit
+		// 		Action	Mobber
+		// 		Addcond
+		// 		{
+		// 			Index 87
+		// 		}
+		// 	}
+		// }
+		// WaveSpawn
+		// {
+		// 	Name	Main1
+		// 	TotalCurrency	100
+		// 	TotalCount	3
+		// 	MaxActive	1
+		// 	SpawnCount	1
+		// 	Where	spawnbot_aggr
+		// 	WaitBeforeStarting	25
+		// 	WaitBetweenSpawns	0
+		// 	RandomSpawn 1
+		// 	Support	1
+		// 	TFBot
+		// 	{
+		// 		Template	T_TFBot_Giant_Scout_FAN
+		// 		Tag	bossbackup
+		// 		Tag giant
+		// 		Attributes	AlwaysCrit
+		// 		Action	Mobber
+		// 		Addcond
+		// 		{
+		// 			Index 87
+		// 		}
+		// 	}
+		// }
+		// WaveSpawn
+		// {
+		// 	Name	Main1
+		// 	TotalCurrency	200
+		// 	TotalCount	45
+		// 	MaxActive	9
+		// 	SpawnCount	3
+		// 	Where	spawnbot
+		// 	Where	spawnbot
+		// 	Where	spawnbot_right
+		// 	WaitBeforeStarting	0
+		// 	WaitBetweenSpawns	6
+		// 	RandomSpawn 1
+		// 	Support	1
+		// 	RandomChoice
+		// 	{
+		// 	NextSpawnerClone 2
+		// 	TFBot
+		// 	{
+		// 		Template	T_TFBot_Demo_Burst
+		// 		Skill	Easy
+		// 	}
+		// 	NextSpawnerClone 2
+		// 	TFBot
+		// 	{
+		// 		Template	T_TFBot_Demo_Burst
+		// 		Skill	Hard
+		// 	}
+		// 	TFBot
+		// 	{
+		// 		Template	T_TFBot_Demo_Burst
+		// 		Tag	flank
+		// 		Skill	Easy
+		// 	}
+		// 	TFBot
+		// 	{
+		// 		Template	T_TFBot_Demo_Burst
+		// 		Tag	flank
+		// 		Skill	Hard
+		// 	}
+		// 	}
+		// }
+		// WaveSpawn
+		// {
+		// 	Name	Main1
+		// 	TotalCurrency	200
+		// 	TotalCount	15
+		// 	MaxActive	3
+		// 	SpawnCount	1
+		// 	Where	spawnbot
+		// 	WaitBeforeStarting	0
+		// 	WaitBetweenSpawns	6
+		// 	RandomSpawn 1
+		// 	Support	1
+		// 	TFBot
+		// 	{
+		// 		Template	ShotgunMinigiant
+		// 	}
+		// }
+	}
+
+}


### PR DESCRIPTION
Removed the custom weapons cause they were borderline op

For wave 4, i switched the following bots:
Giant FAN Super Scouts are now Armored Sandman Scouts and their spawn counts have been halved (8 -> 4) Giant Rapid Fires were replaced by Giant Heavies, their spawncounts and total counts reduced (2 ->1 and 4-> 3 respectively) Replaced the burst fire demos with armored burst fire soldiers

For wave 5:
Reworked the the final subwaves, instead of having 2 heal on kills with a variety of medics, now it has 2 major barrages  and 1 giant heal on kill

For wave 6:
Just increased some total counts for even more chaos

For Planned Obsolescence:
The final phase has been completely reworked