### PR TITLE
Shivering Slumber Boss Bugfix

### DIFF
--- a/scripts/population/mvm_snowpine_rc4_fix1_adv_shivering_slumber.pop
+++ b/scripts/population/mvm_snowpine_rc4_fix1_adv_shivering_slumber.pop
@@ -748,7 +748,14 @@ ShiveringSlumber
 					{
 						Item "player"
 						Name "move speed bonus"
-						Value 0.001
+						Value 0.01
+						Delay 0.1
+					}
+					AddAttribute
+					{
+						Item "player"
+						Name "no_jump"
+						Value 1
 						Delay 0
 					}
 					FireInput


### PR DESCRIPTION
Adjusted Major Mercury's move speed and forced him to AddAttribute "no_jump" so he would stop breaking his $PlaySequence when he was using his caber.