### PR TITLE
Corrected a Spelling Mistake on the Xenomorph Heavy Template (Charon: Crash Landing)

### DIFF
--- a/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
+++ b/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
@@ -1726,7 +1726,10 @@ population
 		{
     		Target "gamerules"
     		Action "RunScriptCode"
-    		Param "ClientPrint(null,3,`\x07F1C232Red Headquarters \x078FCE00: \x07FF3F3FALERT! \x07FF3F3 Field Marshal Mechanus\x078FCE00 and his \x07FF3F3FRight Hand Deadlock\x078FCE00 are here. \x078FCE00Deadlock is known for surprising his enemies. \x07FF3F3 SO WATCH OUT!`)"
+    		Param "
+			ClientPrint(null,3,`\x07F1C232Red Headquarters \x078FCE00: \x07FF3F3FALERT! \x07FF3F3 Field Marshal Mechanus\x078FCE00 and his \x07FF3F3FRight Hand Deadlock\x078FCE00 are here. \x078FCE00Deadlock is known for suprising his enemys. \x07FF3F3 SO WATCH OUT!`)
+			IncludeScript (`buddhamode.nut`,getroottable())
+			"
 		}
 		DoneOutput
 		{
@@ -1757,7 +1760,7 @@ population
                     Cooldown 3 //Time between each weapon switch (Default: 10)
                     Repeats 1 //How many times should bot switch weapons in total (Default: 0 - Infinite)
 				}
-				WeaponSwitch    //Periodically switches weapon
+				WeaponSwitch [$SIGSEGV]  //Periodically switches weapon
                 {
                 	Delay 1 //Time before the first weapon switch starts (Default: 10)
                 	Cooldown 3 //Time between each weapon switch (Default: 10)
@@ -1772,7 +1775,7 @@ population
 					IfHealthBelow 25000 //When set, the task activates only when the bot health is below specified value
 					//IfHealthAbove 0 //When set, the task activates only when the bot health is above specified value
 				}
-				Taunt    //Taunt periodically
+				Taunt [$SIGSEGV]  //Taunt periodically
 				{
     				Delay 1 //Time before the first taunt starts (Default: 10)
     				Repeats 1 //How many times the bot should taunt in total (Default: 0 - Infinite)
@@ -1780,7 +1783,7 @@ population
     				Name "Taunt: The Fubar Fanfare" //If set, uses this item taunt instead of default
     				IfHealthAbove 44999 //When set, the task activates only when the bot health is below specified value
 				}
-				Taunt    //Taunt periodically
+				Taunt [$SIGSEGV]  //Taunt periodically
 				{
     				Delay 7 //Time before the first taunt starts (Default: 10)
     				Repeats 1 //How many times the bot should taunt in total (Default: 0 - Infinite)
@@ -1788,7 +1791,7 @@ population
     				Name "Laugh Taunt" //If set, uses this item taunt instead of default
     				IfHealthAbove 44999 //When set, the task activates only when the bot health is below specified value
 				}
-				Taunt    //Taunt periodically
+				Taunt [$SIGSEGV]  //Taunt periodically
 				{
     				Delay 0 //Time before the first taunt starts (Default: 10)
     				Repeats 1 //How many times the bot should taunt in total (Default: 0 - Infinite)
@@ -1796,29 +1799,21 @@ population
     				Name "Taunt: Unleashed Rage" //If set, uses this item taunt instead of default
     				IfHealthBelow 25000 //When set, the task activates only when the bot health is below specified value
 				}
-				//AddCond   //Adds conditions to bots
-				//{
+				AddCond [$SIGSEGV] //Adds conditions to bots
+				{
     				//Name "TF_COND_REPROGRAMMED" // Condition to apply. List of available conditions https://wiki.teamfortress.com/wiki/Cheats#addcond
-    				//Index 52 //Condition index can be used instead
-    				//Delay 0 // Delay before the condition activates (Default: 0)
-    				//Duration 1.5 // Duration of the condition effect (Default: -1 - infinite duration)
-    				//IfHealthBelow 25000 //When set, the task activates only when the bot health is below specified value
-				//}
-				Taunt    //Taunt periodically
+    				Index 52 //Condition index can be used instead
+    				Delay 0.1 // Delay before the condition activates (Default: 0)
+    				Duration 2 // Duration of the condition effect (Default: -1 - infinite duration)
+    				IfHealthBelow 25000 //When set, the task activates only when the bot health is below specified value
+				}
+				Taunt [$SIGSEGV]  //Taunt periodically
 				{
     				Delay 0 //Time before the first taunt starts (Default: 10)
     				Repeats 1 //How many times the bot should taunt in total (Default: 0 - Infinite)
     				Duration 0.1 //Duration of a looping taunt (Default: 0.1)
     				Name "Taunt: Mourning Mercs" //If set, uses this item taunt instead of default
-    				IfHealthBelow 1000 //When set, the task activates only when the bot health is below specified value
-				}
-				AddCond   //Adds conditions to bots
-				{
-    				Name "TF_COND_REPROGRAMMED" // Condition to apply. List of available conditions https://wiki.teamfortress.com/wiki/Cheats#addcond
-    				Index 52 //Condition index can be used instead
-    				Delay 0 // Delay before the condition activates (Default: 0)
-    				Duration 0.5 // Duration of the condition effect (Default: -1 - infinite duration)
-    				IfHealthBelow 1000 //When set, the task activates only when the bot health is below specified value
+    				IfHealthBelow 2 //When set, the task activates only when the bot health is below specified value
 				}
 				ClassIcon	soldier_bison_rocket_spammer
 				Health	45000
@@ -1832,7 +1827,8 @@ population
 				Item	"the patriot's pouches"
 				Item	"armored authority"
 				AlwaysGlow	1
-				UseHumanAnimations 1   // Use normal class animations instead of a bot / custom model ones
+				AddCond "TF_COND_PREVENT_DEATH" [$SIGSEGV]
+				UseHumanAnimations 1 [$SIGSEGV] // Use normal class animations instead of a bot / custom model ones
 				ItemAttributes
 				{
 					ItemName	"TF_WEAPON_ROCKETLAUNCHER"
@@ -1894,7 +1890,7 @@ population
 				}
 				Message	
 				{
-					Name	"{blue}Field Marshal Mechanus has arrived!"
+					Name	"{red}Field Marshal Mechanus has arrived!"
 					Delay	0.1
 					Repeats	1
 					Cooldown	3
@@ -1902,7 +1898,7 @@ population
 				}
                 Message	
 				{
-					Name	"{blue}Field Marshal Mechanus {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
+					Name	"{red}Field Marshal Mechanus {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
 					Delay	1.75
 					Repeats	1
 					IfHealthBelow	25000
@@ -1915,6 +1911,33 @@ population
                     Delay 1.75
                  	Repeats 1
 					IfHealthBelow	25000
+                }
+				FireInput //Enable buddha mode.
+				{
+ 					Target !self
+  					Action RunScriptCode
+  					Param "self.EnableBuddha()"
+  					Repeats 1
+  					Delay 0.1
+				}
+				FireInput //Disable buddhamode.
+				{
+  					Target !self
+  					Action RunScriptCode
+  					Param "self.DisableBuddha()"
+ 					Repeats 1
+  					Delay 4.5
+  					IfHealthBelow 2
+				}
+				FireInput [$SIGSEGV] 
+                {
+                    Target !self //Entity name to use
+                    Action "RunScriptCode" //Input to fire
+                    Param "self.TakeDamage(999999, 0, self)" //Parameter to use
+                    Delay 0.1 //Delay before firing the input
+					Cooldown 0.1 //Cooldown between firing the input
+                    Repeats 100000 //How many times should the input be fired
+                    IfHealthBelow 2 //When set, the task activates only when the bot health is below specified value
                 }
 			}
 		}
@@ -1930,7 +1953,7 @@ population
 			Where	spawnbot_flank_left
 			TFBot
 			{
-				UseCustomModel "models/bots/sniper_boss/bot_sniper_boss.mdl"   //Use custom model
+				UseCustomModel "models/bots/sniper_boss/bot_sniper_boss.mdl" [$SIGSEGV] //Use custom model
 				Action	Sniper
 				ClassIcon	sniper_machina_nys
 				Health	20000
@@ -1945,6 +1968,7 @@ population
 				Attributes	"UseBossHealthBar"
 				Attributes	"MiniBoss"
 				AlwaysGlow	1
+				AddCond "TF_COND_PREVENT_DEATH" [$SIGSEGV]
 				ItemAttributes
 				{
 					ItemName	"The Machina"
@@ -1972,7 +1996,7 @@ population
 					"airblast vulnerability multiplier"	0.3
 					"override footstep sound set"	2
 				}
-				WeaponSwitch    //Periodically switches weapon
+				WeaponSwitch [$SIGSEGV]  //Periodically switches weapon
                 {
                     Delay 1 //Time before the first weapon switch starts (Default: 10)
                     Cooldown 1 //Time between each weapon switch (Default: 10)
@@ -1987,7 +2011,7 @@ population
 					IfHealthBelow 12000 //When set, the task activates only when the bot health is below specified value
 					//IfHealthAbove 0 //When set, the task activates only when the bot health is above specified value
 				}
-				FireInput   
+				FireInput [$SIGSEGV] 
 				{
     				Target "!self"
     				Action "$BotCommand"
@@ -1997,7 +2021,7 @@ population
     				Repeats 1 //How many times should the input be fired
     				IfHealthBelow 12000
 				}
-				FireInput   
+				FireInput [$SIGSEGV] 
 				{
     				Target "!self"
     				Action "RunScriptCode"
@@ -2026,7 +2050,7 @@ population
 				}
 				Message	
 				{
-					Name	"{blue}Deadlock has spawned behind you!"
+					Name	"{red}Deadlock has spawned behind you!"
 					Delay	0.1
 					Repeats	1
 					Cooldown	3
@@ -2034,7 +2058,7 @@ population
 				}
                 Message	
 				{
-					Name	"{blue}Deadlock {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
+					Name	"{red}Deadlock {FFFFFF}has used their {9BBF4D}RECALL{FFFFFF} Power Up Canteen!"
 					Delay	0.875
 					Repeats	1
 					IfHealthBelow	12000
@@ -2048,7 +2072,34 @@ population
                  	Repeats 1
 					IfHealthBelow	12000
                 }
-				Taunt    //Taunt periodically
+				FireInput //Enable buddha mode.
+				{
+ 					Target !self
+  					Action RunScriptCode
+  					Param "self.EnableBuddha()"
+  					Repeats 1
+  					Delay 0.1
+				}
+				FireInput //Disable buddhamode.
+				{
+  					Target !self
+  					Action RunScriptCode
+  					Param "self.DisableBuddha()"
+ 					Repeats 1
+  					Delay 4.5
+  					IfHealthBelow 2
+				}
+				FireInput [$SIGSEGV] 
+                {
+                    Target !self //Entity name to use
+                    Action "RunScriptCode" //Input to fire
+                    Param "self.TakeDamage(999999, 0, self)" //Parameter to use
+                    Delay 0.1 //Delay before firing the input
+					Cooldown 0.1 //Cooldown between firing the input
+                    Repeats 100000 //How many times should the input be fired
+                    IfHealthBelow 2 //When set, the task activates only when the bot health is below specified value
+                }
+				Taunt [$SIGSEGV]  //Taunt periodically
 				{
     				Delay 0.1 //Time before the first taunt starts (Default: 10)
     				Repeats 1 //How many times the bot should taunt in total (Default: 0 - Infinite)
@@ -2056,29 +2107,21 @@ population
     				Name "Taunt: Unleashed Rage" //If set, uses this item taunt instead of default
     				IfHealthBelow 12000 //When set, the task activates only when the bot health is below specified value
 				}
-				AddCond   //Adds conditions to bots
+				AddCond [$SIGSEGV] //Adds conditions to bots
 				{
     				Name "TF_COND_REPROGRAMMED" // Condition to apply. List of available conditions https://wiki.teamfortress.com/wiki/Cheats#addcond
     				Index 52 //Condition index can be used instead
     				Delay 0.1 // Delay before the condition activates (Default: 0)
-    				Duration 0.5 // Duration of the condition effect (Default: -1 - infinite duration)
+    				Duration 1 // Duration of the condition effect (Default: -1 - infinite duration)
     				IfHealthBelow 12000 //When set, the task activates only when the bot health is below specified value
 				}
-				Taunt    //Taunt periodically
+				Taunt [$SIGSEGV]  //Taunt periodically
 				{
     				Delay 0.1 //Time before the first taunt starts (Default: 10)
     				Repeats 1 //How many times the bot should taunt in total (Default: 0 - Infinite)
     				Duration 0.1 //Duration of a looping taunt (Default: 0.1)
     				Name "Taunt: Mourning Mercs" //If set, uses this item taunt instead of default
-    				IfHealthBelow 1000 //When set, the task activates only when the bot health is below specified value
-				}
-				AddCond   //Adds conditions to bots
-				{
-    				Name "TF_COND_REPROGRAMMED" // Condition to apply. List of available conditions https://wiki.teamfortress.com/wiki/Cheats#addcond
-    				Index 52 //Condition index can be used instead
-    				Delay 0.1 // Delay before the condition activates (Default: 0)
-    				Duration 0.5 // Duration of the condition effect (Default: -1 - infinite duration)
-    				IfHealthBelow 1000 //When set, the task activates only when the bot health is below specified value
+    				IfHealthBelow 2 //When set, the task activates only when the bot health is below specified value
 				}
 			}
 		}

--- a/scripts/population/mvm_charon_b8_int_crash_landing.pop
+++ b/scripts/population/mvm_charon_b8_int_crash_landing.pop
@@ -87,7 +87,7 @@ population
 		T_TFGateBot_Heavy_Easy_Xenomorph
 		{
 			Class Heavy
-			Name	"Heavy Xenomorh"
+			Name	"Heavy Xenomorph"
 			MaxVisionRange	1200
 			//Item	"The Xeno Suit"
 			Item	"the alien cranium"

--- a/scripts/population/mvm_underground_rc3_adv_mining_operation.pop
+++ b/scripts/population/mvm_underground_rc3_adv_mining_operation.pop
@@ -2490,5 +2490,46 @@ population
 				}
 			}
 		}
+		WaveSpawn
+		{
+			//Name	"Boss Supporter"
+			//WaitForAllDead	Complex
+			TotalCurrency	0
+			TotalCount	9999
+			MaxActive	1
+			SpawnCount	1
+			WaitBeforeStarting	999999
+			WaitBetweenSpawns	8
+			Where	spawnbot_invasion
+			HideIcon 1 [$SIGSEGV] // Hides icons from the wave bar. Should use a ClassIcon different from visible ones 
+			Support	1
+			Squad
+			{
+				TFBot
+				{
+					ClassIcon	heavy_shotgun_burst_lite
+				}
+				TFBot
+				{
+					ClassIcon	soldier_nuke2_giant
+				}
+				TFBot
+				{
+					ClassIcon	soldier_homing_spammer_nys_giant
+				}
+				TFBot
+				{
+					ClassIcon	soldier_bison_b
+				}
+				TFBot
+				{
+					ClassIcon	barrage_infinity
+				}
+				TFBot
+				{
+					ClassIcon	soldier_boss_visor
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Corrected a Spelling Mistake on the Xenomorph Heavy Template. It was "Heavy Xenomorh" before instead of "Heavy Xenomorph"
Btw: It seems that for some reason the workshop version of Chrash Landing is now on the event servers. Idk if this is intended.
I have no Idea why my other 2 commits are still here despite them being merged. If possible can you please close them. If not then idk.