### PR TITLE
Nerfs and QoL changes post-release

### DIFF
--- a/scripts/population/mvm_apex_b4_adv_malware_malfunction.pop
+++ b/scripts/population/mvm_apex_b4_adv_malware_malfunction.pop
@@ -307,6 +307,8 @@ WaveSchedule
 				TankExt.SetValueOverrides({
                     TELETANK_UBER_DURATION_MULT = 0.6
                 })
+		ClientPrint(null,3,`\x0799CCFFThis robot battalion has an large number of CUSTOMIZED Tanks!`)
+		ClientPrint(null,3,`\x0799CCFFBring your best tank busting loadout!`)
             "
         }
         DoneOutput
@@ -323,7 +325,7 @@ WaveSchedule
 			TotalCurrency 300
 			Tank
 			{
-				Health 27000
+				Health 24000
 				Speed 75
                 Name "teletank"
                 ClassIcon tank_tele
@@ -345,7 +347,7 @@ WaveSchedule
                 Target    wave_start_relay
                 Action    RunScriptCode
                 Param    "
-                ClientPrint(null,3,`\x0799CCFFA Teleporter Tank has been deployed with 27k health!`)
+                ClientPrint(null,3,`\x0799CCFFA Teleporter Tank has been deployed with 24k health!`)
                 "
             }
         }
@@ -391,7 +393,7 @@ WaveSchedule
             SpawnCount	3
             WaitBeforeStarting	3
             WaitBetweenSpawns  10
-            Support	1
+            Support	Limited
             Where	spawnbot_all
             RandomChoice
 			{
@@ -435,8 +437,8 @@ WaveSchedule
             Name	wave1support
             TotalCurrency	100
             TotalCount	30
-            MaxActive	6
-            SpawnCount	6
+            MaxActive	5
+            SpawnCount	5
             WaitBeforeStarting 10
             WaitBetweenSpawns  10
             Support	1
@@ -1321,16 +1323,7 @@ WaveSchedule
 			TFBot
 			{
 				Template T_TFBot_Giant_Soldier_Extended_Battalion
-				ClassIcon 	soldier_infinite_backup
-				Name "Giant Rapid Backup Soldier"
 				Tag "default"
-				ItemAttributes
-				{
-					ItemName "TF_WEAPON_ROCKETLAUNCHER"
-					"faster reload rate" -0.8
-					"fire rate bonus" 0.5
-					"Projectile speed increased" 0.65
-				}
                 CharacterAttributes
 				{
 					"deploy time increased" 0.5
@@ -1350,16 +1343,7 @@ WaveSchedule
 			TFBot
 			{
 				Template T_TFBot_Giant_Soldier_Extended_Battalion
-				ClassIcon 	soldier_infinite_backup
-				Name "Giant Rapid Backup Soldier"
 				Tag "default"
-				ItemAttributes
-				{
-					ItemName "TF_WEAPON_ROCKETLAUNCHER"
-					"faster reload rate" -0.8
-					"fire rate bonus" 0.5
-					"Projectile speed increased" 0.65
-				}
                 CharacterAttributes
 				{
 					"deploy time increased" 0.5
@@ -1421,7 +1405,7 @@ WaveSchedule
 			TotalCurrency 100
 			Tank
 			{
-				Health 32000
+				Health 30000
 				Speed 60
                 Name "tankdozer"
                 ClassIcon tankdozer_lite_sentry
@@ -1443,7 +1427,7 @@ WaveSchedule
                 Target    wave_start_relay
                 Action    RunScriptCode
                 Param    "
-                ClientPrint(null,3,`\x0799CCFFA Tankdozer has been deployed with 32k health!`)
+                ClientPrint(null,3,`\x0799CCFFA Tankdozer has been deployed with 30k health!`)
 				ClientPrint(null,3,`\x0799CCFFHINT: Its sentry gun and armor can be destroyed with enough firepower!`)
 				ClientPrint(null,3,`\x0799CCFFSentry Gun HP: 4000`)
                 "
@@ -1569,6 +1553,9 @@ WaveSchedule
                 `boss_path_ra_1`
                 `boss_path_rb_1`
                 ])
+		ClientPrint(null,3,`\x0799CCFFTwo Uber Tanks have been spotted!`)
+		ClientPrint(null,3,`\x0799CCFFHINT: Destroy all following robots to deactivate the tanks' Uber!`)
+		ClientPrint(null,3,`\x0799CCFFBonk Scouts, Giant Soldiers and Demomen`)
             "
         }
         DoneOutput
@@ -1594,6 +1581,7 @@ WaveSchedule
 				Name "Giant Crit Heal Soldier"
 				Health 4200
 				Item "The Black Box"
+				Item "Lo-Fi Longwave"
 				Skill Expert
 				Attributes MiniBoss
 				WeaponRestrictions PrimaryOnly
@@ -1614,6 +1602,7 @@ WaveSchedule
 				CharacterAttributes
 				{
 					"move speed bonus"	0.5
+					"head scale" 1.25
 					"damage force reduction" 0.4
 					"airblast vulnerability multiplier" 0.4
 					"override footstep sound set" 3
@@ -1634,8 +1623,13 @@ WaveSchedule
             {
                Template T_TFBot_Giant_Demoman
                Item	"The Tide Turner"
+	       Item "Lo-Fi Longwave"
                ClassIcon demo_infinite
 			   Tag "default"
+		CharacterAttributes
+				{
+					"head scale" 1.25
+				}
             }
         }
         WaveSpawn
@@ -1654,7 +1648,7 @@ WaveSchedule
 				Class Scout
 				Skill Easy
 				Item "Bonk! Atomic Punch"
-				Item "Bonk Helm"
+				Item "Lo-Fi Longwave"
 				ClassIcon scout_bonk_scatter_nys2
 				CharacterAttributes
 				{
@@ -1721,8 +1715,6 @@ WaveSchedule
                 Action    RunScriptCode
                 Param    "
                 ClientPrint(null,3,`\x0799CCFFTwo Uber Tanks have been deployed with 15k health EACH!`)
-				ClientPrint(null,3,`\x0799CCFFHINT: Destroy all following robots to deactivate the tanks' Uber!`)
-				ClientPrint(null,3,`\x0799CCFFBonk Scouts, Giant Soldiers and Demomen`)
                 "
             }
         }

--- a/scripts/population/mvm_apex_b4_adv_malware_malfunction.pop
+++ b/scripts/population/mvm_apex_b4_adv_malware_malfunction.pop
@@ -307,7 +307,7 @@ WaveSchedule
 				TankExt.SetValueOverrides({
                     TELETANK_UBER_DURATION_MULT = 0.6
                 })
-		ClientPrint(null,3,`\x0799CCFFThis robot battalion has an large number of CUSTOMIZED Tanks!`)
+		ClientPrint(null,3,`\x0799CCFFThis robot battalion has a large number of CUSTOMIZED Tanks!`)
 		ClientPrint(null,3,`\x0799CCFFBring your best tank busting loadout!`)
             "
         }


### PR DESCRIPTION
Wave 1:
First wave now announces that mission will have a large number of tanks
Decreased Teleporter Tank HP from 27k to 24k
Backburner/SMG Snipers are now Support Limited
Decreased spawn count of Liberty Soldiers from 6 to 5


Wave 5:
Only the final Giant Battalion's Soldier is a Rapid Fire Soldier
Decreased Tankdozer HP from 32k to 30k


Wave 6:
Uber Tank mechanics are now announced before wave starts
Added Lo-Fi Longwave hats to first subwave bots to indicate that they need to be destroyed to disable Uber Tank