### PR TITLE
Small Changes on Bogland: Mud Maker and Underground: Mining Operation

### DIFF
--- a/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
+++ b/scripts/population/mvm_bogland_rc10_adv_mud_maker.pop
@@ -9,9 +9,10 @@ population
 	Advanced	1
 	AllowBotExtraSlots 1  
 	PrecacheModel                    models/bots/boss_bot/boss_blimp_main.mdl  
-    PrecacheModel                    models/bots/boss_bot/boss_blimp_main_damage1.mdl  
-    PrecacheModel                    models/bots/boss_bot/boss_blimp_main_damage2.mdl  
-    PrecacheModel                    models/bots/boss_bot/boss_blimp_main_damage3.mdl  
+    	PrecacheModel                    models/bots/boss_bot/boss_blimp_main_damage1.mdl  
+    	PrecacheModel                    models/bots/boss_bot/boss_blimp_main_damage2.mdl  
+    	PrecacheModel                    models/bots/boss_bot/boss_blimp_main_damage3.mdl
+	PrecacheModel "models/bots/sniper_boss/bot_sniper_boss.mdl"
 	ExtraTankPath   //Adds tank path to follow
 	{
 		Name "tank_path_sky_1" //name of the starting path node prefix. First tank node name would be name_1

--- a/scripts/population/mvm_underground_rc3_adv_mining_operation.pop
+++ b/scripts/population/mvm_underground_rc3_adv_mining_operation.pop
@@ -2452,7 +2452,7 @@ population
 			MaxActive	4
 			SpawnCount	1
 			WaitBeforeStarting	8
-			WaitBetweenSpawns	5
+			WaitBetweenSpawns	7.5
 			Where	spawnbot_side
 			Support	1
 			TFBot


### PR DESCRIPTION
Mud Maker:
Preached the Giant Sniper Model because of a crash that appears when deadlock spawns for people who don't have the model downloaded.

Mining Operation:
Added Crits to the Pyro Support. 
(doesnt seem like it but i did. cant see it bc of an earlier save of changes. the same change from earlier with the wbs of the pyro support was also reverted. thats why it only appears in this commit.)